### PR TITLE
Remove `osmnx`, `scikit-learn` from requirements.txt

### DIFF
--- a/src/planner/simple/requirements.txt
+++ b/src/planner/simple/requirements.txt
@@ -5,5 +5,3 @@ networkx >= 2.7.1
 pydantic >= 1.9.0
 python-multipart >= 0.0.5
 uvicorn >= 0.17
-osmnx >= 1.3.0
-scikit-learn >= 1.2.2


### PR DESCRIPTION
I have removed unused libraries from the requirements.txt file. I have identified and removed the following libraries that were no longer in use:
- `osmnx`
- `scikit-learn`