### PR TITLE
Refactor/stand-alone ondemand simulator

### DIFF
--- a/src/base_simulators/ondemand/controller.py
+++ b/src/base_simulators/ondemand/controller.py
@@ -10,11 +10,11 @@ import fastapi
 
 import httputil
 import jschema.events
-from config import env
-from core import Network
-from gtfs import GtfsFlexFilesReader
-from jschema import query, response
-from simulation import Simulation
+from .config import env
+from .core import Network
+from .gtfs import GtfsFlexFilesReader
+from .jschema import query, response
+from .simulation import Simulation
 
 logger = logging.getLogger(__name__)
 app = fastapi.FastAPI(

--- a/src/base_simulators/ondemand/controller.py
+++ b/src/base_simulators/ondemand/controller.py
@@ -14,7 +14,7 @@ from .config import env
 from .core import Network
 from .gtfs import GtfsFlexFilesReader
 from .jschema import query, response
-from .simulation import Simulation
+from .simulation import Simulation, CarSetting
 
 logger = logging.getLogger(__name__)
 app = fastapi.FastAPI(
@@ -106,7 +106,14 @@ async def setup(settings: query.Setup):
         trips=trips,
         board_time=settings.board_time,
         max_delay_time=settings.max_delay_time,
-        settings={mobility.mobility_id: mobility for mobility in settings.mobilities},
+        settings=[
+            CarSetting(
+                mobility_id=mobility.mobility_id,
+                capacity=mobility.capacity,
+                trip=trips[mobility.trip_id],
+                stop=stops[mobility.stop]
+            ) for mobility in settings.mobilities
+        ],
     )
 
     return {

--- a/src/base_simulators/ondemand/event.py
+++ b/src/base_simulators/ondemand/event.py
@@ -3,8 +3,8 @@
 import datetime
 import typing
 
-from core import EventType, Mobility, User
-from environment import Environment
+from .core import EventType, Mobility, User
+from .environment import Environment
 
 
 class TriggerEvent:

--- a/src/base_simulators/ondemand/gtfs.py
+++ b/src/base_simulators/ondemand/gtfs.py
@@ -7,7 +7,7 @@ import io
 import zipfile
 import re
 
-from core import Stop, Group, StopTime, Service, Trip
+from .core import Stop, Group, StopTime, Service, Trip
 
 
 p = re.compile(r"(\d\d?):(\d\d?):(\d\d?)")

--- a/src/base_simulators/ondemand/jschema/query.py
+++ b/src/base_simulators/ondemand/jschema/query.py
@@ -16,7 +16,9 @@ class InputFilesItem(BaseModel):
     filename: str | None = None
     fetch_url: AnyHttpUrl | None = None
 
-    @root_validator
+    # ToDo: `@root_validator` are deprecated.
+    # And, `skip_on_failure` must be `True`
+    @root_validator(skip_on_failure=True)
     def check_exist_either(cls, values):
         if values.get("filename") or values.get("fetch_url"):
             return values

--- a/src/base_simulators/ondemand/jschema/query.py
+++ b/src/base_simulators/ondemand/jschema/query.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel, Field, AnyHttpUrl, root_validator, constr
 
-from jschema.events import ReserveEvent, DepartEvent, Event as OtherEvent
+from .events import ReserveEvent, DepartEvent, Event as OtherEvent
 
 
 class Mobility(BaseModel):

--- a/src/base_simulators/ondemand/jschema/response.py
+++ b/src/base_simulators/ondemand/jschema/response.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from pydantic import BaseModel
 
-from jschema.events import ReservedEvent, DepartedEvent, ArrivedEvent
+from .events import ReservedEvent, DepartedEvent, ArrivedEvent
 
 
 class Message(BaseModel):

--- a/src/base_simulators/ondemand/mobility.py
+++ b/src/base_simulators/ondemand/mobility.py
@@ -10,8 +10,8 @@ from datetime import datetime, timedelta
 import itertools
 import functools
 
-from core import Trip, Stop, Network, User, Mobility
-from event import EventQueue
+from .core import Trip, Stop, Network, User, Mobility
+from .event import EventQueue
 
 
 logger = logging.getLogger(__name__)
@@ -95,7 +95,6 @@ class Car(Mobility):
         self._passengers: typing.Dict[str, User] = {}
         _, end_window = self.window()
         self.env.process(self._move_to_initial_stop(end_window)) # move to initial stop at end_window
-
 
     def __str__(self):
         reserved = [e.user_id for e in self._reserved_users.values()]

--- a/src/base_simulators/ondemand/simulation.py
+++ b/src/base_simulators/ondemand/simulation.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
-
+import typing
 from datetime import datetime, timedelta
 from logging import getLogger
 
@@ -9,7 +8,6 @@ from .environment import Environment
 from .core import Network, User, Trip
 from .event import EventQueue
 from .mobility import CarManager, CarSetting
-from .jschema.query import Mobility
 
 logger = getLogger(__name__)
 
@@ -17,9 +15,7 @@ logger = getLogger(__name__)
 class Simulation:
     def __init__(self, start_time: datetime, network: Network,
                  board_time: float, max_delay_time: float,
-                 trips: dict[str, Trip], settings: dict[str, Mobility]):
-        assert {e.trip_id for e in settings.values()} <= trips.keys(), \
-            f"{{e.trip_id for e in settings.values()}} must include in {trips.keys()}"
+                 trips: dict[str, Trip], settings: typing.Collection[CarSetting]):
         self.env = Environment(start_time=start_time)
         self.event_queue = EventQueue(self.env)
         self.network = network
@@ -34,14 +30,7 @@ class Simulation:
             event_queue=self.event_queue,
             board_time=board_time,
             max_delay_time=max_delay_time,
-            settings=[
-                CarSetting(
-                    mobility_id=mobility_id,
-                    capacity=mobility.capacity,
-                    trip=trips[mobility.trip_id],
-                    stop=self.stops[mobility.stop]
-                ) for mobility_id, mobility in settings.items()
-            ]
+            settings=settings
         )
 
     def start(self):

--- a/src/base_simulators/ondemand/simulation.py
+++ b/src/base_simulators/ondemand/simulation.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from logging import getLogger
 
-from environment import Environment
-from core import Network, User, Trip
-from event import EventQueue
-from mobility import CarManager, CarSetting
-from jschema.query import Mobility
+from .environment import Environment
+from .core import Network, User, Trip
+from .event import EventQueue
+from .mobility import CarManager, CarSetting
+from .jschema.query import Mobility
 
 logger = getLogger(__name__)
 

--- a/src/base_simulators/ondemand/test/test_gtfs.py
+++ b/src/base_simulators/ondemand/test/test_gtfs.py
@@ -3,8 +3,8 @@
 import unittest
 import datetime
 
-from core import Stop, Group, StopTime, Service, Trip
-from gtfs import GtfsFlexFilesReader
+from ..core import Stop, Group, StopTime, Service, Trip
+from ..gtfs import GtfsFlexFilesReader
 
 
 class ReadFlexTestCase(unittest.TestCase):

--- a/src/base_simulators/ondemand/test/test_integration.py
+++ b/src/base_simulators/ondemand/test/test_integration.py
@@ -4,14 +4,9 @@ import unittest
 import logging
 from datetime import datetime, date, time, timedelta
 
-import os, sys 
-module_path = os.path.abspath(os.path.join(f'{os.path.dirname(__file__)}/..'))
-if module_path not in sys.path:
-    sys.path.append(module_path)
-
-from simulation import Simulation
-from core import EventType, Stop, StopTime, Service, Trip, Group, Network
-from jschema.query import Mobility
+from ..simulation import Simulation
+from ..core import EventType, Stop, StopTime, Service, Trip, Group, Network
+from ..jschema.query import Mobility
 
 logger = logging.getLogger(__name__)
 
@@ -1632,6 +1627,7 @@ class TwoMobilityTestCase(unittest.TestCase):
                 'location': {"locationId": "Stop1", "lat": ..., "lng": ...},
             }
         }], triggered_events)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/base_simulators/ondemand/test/test_integration.py
+++ b/src/base_simulators/ondemand/test/test_integration.py
@@ -4,9 +4,8 @@ import unittest
 import logging
 from datetime import datetime, date, time, timedelta
 
-from ..simulation import Simulation
+from ..simulation import Simulation, CarSetting
 from ..core import EventType, Stop, StopTime, Service, Trip, Group, Network
-from ..jschema.query import Mobility
 
 logger = logging.getLogger(__name__)
 
@@ -34,39 +33,38 @@ class OneMobilityTestCase(unittest.TestCase):
         self.network.add_edge(self.stop1.stop_id, self.stop2.stop_id, 30, with_rev=True)
         self.network.add_edge(self.stop1.stop_id, self.stop3.stop_id, 15, with_rev=True)
         self.network.add_edge(self.stop2.stop_id, self.stop3.stop_id, 20, with_rev=True)
+        self.trip = Trip(
+            service=Service(
+                start_date=self.base_datetime.date(),
+                end_date=self.base_datetime.date() + timedelta(days=1),
+                monday=True, tuesday=True, wednesday=True, thursday=True, friday=True,
+                saturday=True, sunday=True
+            ),
+            stop_time=StopTime(
+                group=Group(
+                    group_id=...,
+                    name=...,
+                    locations=[stop for stop in self.stops.values()]
+                ),
+                start_window=timedelta(hours=1),
+                end_window=timedelta(hours=23),
+            )
+        )
 
         self.simulation = Simulation(
             start_time=self.base_datetime,
             board_time=10,
             max_delay_time=30,
             network=self.network,
-            trips={
-                "trip": Trip(
-                    service=Service(
-                        start_date=self.base_datetime.date(),
-                        end_date=self.base_datetime.date() + timedelta(days=1),
-                        monday=True, tuesday=True, wednesday=True, thursday=True, friday=True,
-                        saturday=True, sunday=True
-                    ),
-                    stop_time=StopTime(
-                        group=Group(
-                            group_id=...,
-                            name=...,
-                            locations=[stop for stop in self.stops.values()]
-                        ),
-                        start_window=timedelta(hours=1),
-                        end_window=timedelta(hours=23),
-                    )
-                )
-            },
-            settings={
-                "trip": Mobility(
+            trips={"trip": self.trip},
+            settings=[
+                CarSetting(
                     mobility_id="trip",
-                    trip_id="trip",
+                    trip=self.trip,
                     capacity=2,
-                    stop=self.stops["Stop1"].stop_id
+                    stop=self.stops["Stop1"]
                 )
-            }
+            ]
         )
         self.simulation.start()
 
@@ -1486,6 +1484,40 @@ class TwoMobilityTestCase(unittest.TestCase):
         self.network.add_edge(self.stop1.stop_id, self.stop2.stop_id, 30, with_rev=True)
         self.network.add_edge(self.stop1.stop_id, self.stop3.stop_id, 40, with_rev=True)
         self.network.add_edge(self.stop2.stop_id, self.stop3.stop_id, 50, with_rev=True)
+        self.trip1 = Trip(
+            service=Service(
+                start_date=self.base_datetime.date(),
+                end_date=self.base_datetime.date() + timedelta(days=1),
+                monday=True, tuesday=True, wednesday=True, thursday=True, friday=True,
+                saturday=True, sunday=True
+            ),
+            stop_time=StopTime(
+                group=Group(
+                    group_id=...,
+                    name=...,
+                    locations=[stop for stop in self.stops.values()]
+                ),
+                start_window=timedelta(hours=1),
+                end_window=timedelta(hours=23),
+            )
+        )
+        self.trip2 = Trip(
+            service=Service(
+                start_date=self.base_datetime.date(),
+                end_date=self.base_datetime.date() + timedelta(days=1),
+                monday=True, tuesday=True, wednesday=True, thursday=True, friday=True,
+                saturday=True, sunday=True
+            ),
+            stop_time=StopTime(
+                group=Group(
+                    group_id=...,
+                    name=...,
+                    locations=[stop for stop in self.stops.values()]
+                ),
+                start_window=timedelta(hours=1),
+                end_window=timedelta(hours=23),
+            )
+        )
 
         self.simulation = Simulation(
             start_time=self.base_datetime,
@@ -1493,55 +1525,23 @@ class TwoMobilityTestCase(unittest.TestCase):
             board_time=10,
             max_delay_time=30,
             trips={
-                "trip1": Trip(
-                    service=Service(
-                        start_date=self.base_datetime.date(),
-                        end_date=self.base_datetime.date() + timedelta(days=1),
-                        monday=True, tuesday=True, wednesday=True, thursday=True, friday=True,
-                        saturday=True, sunday=True
-                    ),
-                    stop_time=StopTime(
-                        group=Group(
-                            group_id=...,
-                            name=...,
-                            locations=[stop for stop in self.stops.values()]
-                        ),
-                        start_window=timedelta(hours=1),
-                        end_window=timedelta(hours=23),
-                    )
-                ),
-                "trip2": Trip(
-                    service=Service(
-                        start_date=self.base_datetime.date(),
-                        end_date=self.base_datetime.date() + timedelta(days=1),
-                        monday=True, tuesday=True, wednesday=True, thursday=True, friday=True,
-                        saturday=True, sunday=True
-                    ),
-                    stop_time=StopTime(
-                        group=Group(
-                            group_id=...,
-                            name=...,
-                            locations=[stop for stop in self.stops.values()]
-                        ),
-                        start_window=timedelta(hours=1),
-                        end_window=timedelta(hours=23),
-                    )
-                )
+                "trip1": self.trip1,
+                "trip2": self.trip2
             },
-            settings={
-                "trip1": Mobility(
+            settings=[
+                CarSetting(
                     mobility_id="trip1",
-                    trip_id="trip1",
+                    trip=self.trip1,
                     capacity=1,
-                    stop=self.stops["Stop1"].stop_id
+                    stop=self.stops["Stop1"]
                 ),
-                "trip2": Mobility(
+                CarSetting(
                     mobility_id="trip2",
-                    trip_id="trip2",
+                    trip=self.trip2,
                     capacity=1,
-                    stop=self.stops["Stop2"].stop_id
+                    stop=self.stops["Stop2"]
                 )
-            }
+            ]
         )
         self.simulation.start()
 

--- a/src/base_simulators/ondemand/test/test_mobility.py
+++ b/src/base_simulators/ondemand/test/test_mobility.py
@@ -5,9 +5,9 @@ from datetime import datetime, timedelta
 from unittest import TestCase
 from unittest.mock import Mock
 
-from core import User, Stop, Group, Trip, Service, StopTime as flex_StopTime, Network
-from environment import Environment
-from mobility import Car, Route, StopTime, Delay, CarManager, CarSetting
+from ..core import User, Stop, Group, Trip, Service, StopTime as flex_StopTime, Network
+from ..environment import Environment
+from ..mobility import Car, Route, StopTime, Delay, CarManager, CarSetting
 
 base_datetime = datetime(year=2022, month=1, day=1)
 stops = [

--- a/src/base_simulators/ondemand/test/test_service.py
+++ b/src/base_simulators/ondemand/test/test_service.py
@@ -4,7 +4,7 @@ import unittest
 import logging
 from datetime import date
 
-from core import Service
+from ..core import Service
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## On-demand simulator can now run stand-alone.

### `@root_validator` are deprecated
Pydantic V1 style `@root_validator` validators are deprecated. If we previously used @root_validator with the default `pre=False` setting, we are now required to specify `skip_on_failure=True`. This is a temporary solution, and it's advisable to migrate to Pydantic V2 style `@model_validator`.

### Relative import
The modules of the "ondemand simulator" have been modified to import modules from the same package using relative paths rather than absolute paths. This change makes it easier to move the `base_simulator/ondemand` simulator to a different directory and run it as a stand-alone application.

### `Simulation` takes `mobility.CarSetting` as `settings` argument
`Simulation` should take `mobility.CarSetting` instead of `jschema.query.Mobility` as `settings` argument.
Simulation should ideally be decoupled from jschema. JSON format is just one way to configure Simulation. In the future, we might use other methods besides JSON to configure it.