### PR TITLE
update OpenTripPlanner to v2.4

### DIFF
--- a/src/base_simulators/scheduled/gtfs.py
+++ b/src/base_simulators/scheduled/gtfs.py
@@ -80,9 +80,9 @@ class GtfsFilesReader:
         self._agencies: typing.Dict[str, Agency] = {}
         self.stops: typing.Dict[str, Stop] = {}
         self._routes: typing.Dict[str, Route] = {}
-        self._stop_times: typing.Dict[
-            str, typing.List[StopTime]
-        ] = collections.defaultdict(list)
+        self._stop_times: typing.Dict[str, typing.List[StopTime]] = (
+            collections.defaultdict(list)
+        )
         self._services: typing.Dict[str, Service] = {}
         self.trips: typing.Dict[str, Trip] = {}
 

--- a/src/planner/opentripplanner/Dockerfile
+++ b/src/planner/opentripplanner/Dockerfile
@@ -3,7 +3,7 @@ USER root
 RUN apt-get -y update \
  && apt-get install -y python3-pip wget \
  && mkdir /root/otp \
- && wget "https://repo1.maven.org/maven2/org/opentripplanner/otp/2.2.0/otp-2.2.0-shaded.jar" -P /root/otp/
+ && wget "https://repo1.maven.org/maven2/org/opentripplanner/otp/2.4.0/otp-2.4.0-shaded.jar" -O /root/otp/otp-shaded.jar
 
 WORKDIR /home
 COPY requirements.txt ./

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -241,7 +241,7 @@ async def setup(request: fastapi.Request, setting: query.Setup):
         "java",
         "-Xmx5G",
         "-jar",
-        "/root/otp/otp-2.2.0-shaded.jar",
+        "/root/otp/otp-shaded.jar",
         "--build",
         "--port",
         str(env.OPENTRIPPLANNER_PORT),

--- a/src/planner/simple/gtfs/reader.py
+++ b/src/planner/simple/gtfs/reader.py
@@ -69,9 +69,9 @@ def parse_calendar_dates(row: typing.Dict[str, str]):
 class FilesReader:
     def __init__(self, archive: zipfile.ZipFile):
         self.stops: typing.Dict[str, Location] = {}
-        self._stop_times: typing.Dict[
-            str, typing.List[StopTime]
-        ] = collections.defaultdict(list)
+        self._stop_times: typing.Dict[str, typing.List[StopTime]] = (
+            collections.defaultdict(list)
+        )
         self._services: typing.Dict[str, Service] = {}
         self.trips: typing.Dict[str, Trip] = {}
 


### PR DESCRIPTION
We have been using v2.2 but are updating to v2.4 to handle GTFS including `block_id`.

We will always run the executable with the same name, regardless of the OTP version.