### PR TITLE
Block

### DIFF
--- a/src/base_simulators/scheduled/controller.py
+++ b/src/base_simulators/scheduled/controller.py
@@ -84,7 +84,7 @@ async def setup(settings: query.Setup):
     sim = Simulation(
         start_time=datetime.datetime.strptime(settings.reference_time, "%Y%m%d"),
         capacity=settings.mobility.capacity,
-        trips=trips
+        trips=trips,
     )
 
     return {"message": "successfully configured."}

--- a/src/base_simulators/scheduled/controller.py
+++ b/src/base_simulators/scheduled/controller.py
@@ -76,12 +76,16 @@ async def setup(settings: query.Setup):
         )
     with zipfile.ZipFile(io.BytesIO(data)) as archive:
         gtfs_files = gtfs.GtfsFilesReader(archive)
-    trips = gtfs_files.trips
 
-    start_time = datetime.datetime.strptime(settings.reference_time, "%Y%m%d")
-    capacity = settings.mobility.capacity
+    trips = gtfs_files.trips
+    # ToDo: handle gtfs_files.blocks
+
     global sim
-    sim = Simulation(start_time=start_time, capacity=capacity, trips=trips)
+    sim = Simulation(
+        start_time=datetime.datetime.strptime(settings.reference_time, "%Y%m%d"),
+        capacity=settings.mobility.capacity,
+        trips=trips
+    )
 
     return {"message": "successfully configured."}
 

--- a/src/base_simulators/scheduled/controller.py
+++ b/src/base_simulators/scheduled/controller.py
@@ -77,14 +77,12 @@ async def setup(settings: query.Setup):
     with zipfile.ZipFile(io.BytesIO(data)) as archive:
         gtfs_files = gtfs.GtfsFilesReader(archive)
 
-    trips = gtfs_files.trips
-    # ToDo: handle gtfs_files.blocks
-
     global sim
     sim = Simulation(
         start_time=datetime.datetime.strptime(settings.reference_time, "%Y%m%d"),
         capacity=settings.mobility.capacity,
-        trips=trips,
+        trips=gtfs_files.trips,
+        blocks=gtfs_files.blocks,
     )
 
     return {"message": "successfully configured."}

--- a/src/base_simulators/scheduled/core.py
+++ b/src/base_simulators/scheduled/core.py
@@ -186,7 +186,9 @@ class Trip:
     def end_time(self, at: date) -> datetime:
         raise NotImplementedError()
 
-    def paths(self, org: Stop, dst: Stop, at: date) -> typing.Generator[Path, typing.Any, None]:
+    def paths(
+        self, org: Stop, dst: Stop, at: date
+    ) -> typing.Generator[Path, typing.Any, None]:
         raise NotImplementedError()
 
 

--- a/src/base_simulators/scheduled/core.py
+++ b/src/base_simulators/scheduled/core.py
@@ -133,43 +133,6 @@ class Service:
 
 
 @dataclasses.dataclass(frozen=True)
-class Trip:
-    """Sequence of two or more stops that occur during a specific time period."""
-
-    route: Route
-    service: Service
-    stop_times: typing.List[StopTime]
-
-    def __post_init__(self):
-        assert len(self.stop_times) >= 2
-
-    def stop_times_at(self, at_date: date):
-        return [
-            StopTimeWithDateTime(stop_time=stop_time, reference_date=at_date)
-            for stop_time in self.stop_times
-        ]
-
-    def start_time(self, at: date):
-        return list(self.stop_times_at(at))[0].arrival
-
-    def end_time(self, at: date):
-        return list(self.stop_times_at(at))[-1].departure
-
-    def paths(self, org: Stop, dst: Stop, at: date):
-        if not self.service.is_operation(at):
-            return
-
-        for stop_time_org in self.stop_times_at(at):
-            if stop_time_org.stop == org:
-                for stop_time_dst in self.stop_times_at(at):
-                    if (
-                        stop_time_dst.stop == dst
-                        and stop_time_org.departure < stop_time_dst.arrival
-                    ):
-                        yield Path(pick_up=stop_time_org, drop_off=stop_time_dst)
-
-
-@dataclasses.dataclass(frozen=True)
 class Path:
     pick_up: StopTimeWithDateTime
     drop_off: StopTimeWithDateTime
@@ -202,6 +165,29 @@ class Path:
     @property
     def arrival(self):
         return self.drop_off.arrival
+
+
+class Trip:
+    """Sequence of two or more stops during a specific time period using a vehicle"""
+
+    @property
+    def stops(self) -> typing.List[Stop]:
+        raise NotImplementedError()
+
+    def is_operation(self, at_date: date) -> bool:
+        raise NotImplementedError()
+
+    def stop_times_at(self, at_date: date) -> typing.List[StopTimeWithDateTime]:
+        raise NotImplementedError()
+
+    def start_time(self, at: date) -> datetime:
+        raise NotImplementedError()
+
+    def end_time(self, at: date) -> datetime:
+        raise NotImplementedError()
+
+    def paths(self, org: Stop, dst: Stop, at: date) -> typing.Generator[Path, typing.Any, None]:
+        raise NotImplementedError()
 
 
 @dataclasses.dataclass
@@ -242,7 +228,7 @@ class Mobility:
         if at is None:
             at = self.operation_date
 
-        return self._trip if self._trip.service.is_operation(at) else None
+        return self._trip if self._trip.is_operation(at) else None
 
     @property
     def operation_date(self):

--- a/src/base_simulators/scheduled/gtfs.py
+++ b/src/base_simulators/scheduled/gtfs.py
@@ -8,7 +8,8 @@ import io
 import zipfile
 import re
 
-from core import Agency, Stop, Route, StopTime, Service, Trip
+from core import Agency, Stop, Route, StopTime, Service
+from trip import SingleTrip
 
 p = re.compile(r"(\d\d?):(\d\d?):(\d\d?)")
 
@@ -84,7 +85,8 @@ class GtfsFilesReader:
             collections.defaultdict(list)
         )
         self._services: typing.Dict[str, Service] = {}
-        self.trips: typing.Dict[str, Trip] = {}
+        self.trips: typing.Dict[str, SingleTrip] = {}
+        self.blocks: typing.Dict[str, typing.List[SingleTrip]] = collections.defaultdict(list)
 
         with archive.open("agency.txt") as f:
             for k, v in GtfsReader(f, parse_agency):
@@ -114,7 +116,10 @@ class GtfsFilesReader:
 
         with archive.open("trips.txt") as f:
             for k, v in GtfsReader(f, self.parse_trip):
-                self.trips.update({k: v})
+                if block_id := v.block_id:
+                    self.blocks[block_id].append(v)
+                else:
+                    self.trips.update({k: v})
 
     def parse_route(self, row: typing.Dict[str, str]):
         return row["route_id"], Route(
@@ -134,8 +139,9 @@ class GtfsFilesReader:
         )
 
     def parse_trip(self, row: typing.Dict[str, str]):
-        return row["trip_id"], Trip(
+        return row["trip_id"], SingleTrip(
             route=self._routes[row["route_id"]],
             service=self._services[row["service_id"]],
             stop_times=self._stop_times[row["trip_id"]],
+            block_id=row["block_id"],
         )

--- a/src/base_simulators/scheduled/gtfs.py
+++ b/src/base_simulators/scheduled/gtfs.py
@@ -86,7 +86,9 @@ class GtfsFilesReader:
         )
         self._services: typing.Dict[str, Service] = {}
         self.trips: typing.Dict[str, SingleTrip] = {}
-        self.blocks: typing.Dict[str, typing.List[SingleTrip]] = collections.defaultdict(list)
+        self.blocks: typing.Dict[str, typing.List[SingleTrip]] = (
+            collections.defaultdict(list)
+        )
 
         with archive.open("agency.txt") as f:
             for k, v in GtfsReader(f, parse_agency):

--- a/src/base_simulators/scheduled/gtfs.py
+++ b/src/base_simulators/scheduled/gtfs.py
@@ -145,5 +145,5 @@ class GtfsFilesReader:
             route=self._routes[row["route_id"]],
             service=self._services[row["service_id"]],
             stop_times=self._stop_times[row["trip_id"]],
-            block_id=row["block_id"],
+            block_id=row.get("block_id", None),
         )

--- a/src/base_simulators/scheduled/simulation.py
+++ b/src/base_simulators/scheduled/simulation.py
@@ -16,7 +16,10 @@ logger = getLogger(__name__)
 
 class Simulation:
     def __init__(
-        self, start_time: datetime, capacity: int, trips: typing.Dict[str, Trip]
+        self,
+        start_time: datetime,
+        capacity: int,
+        trips: typing.Dict[str, Trip],
     ) -> None:
         self.env = Environment(start_time=start_time)
         self.event_queue = EventQueue()
@@ -33,9 +36,9 @@ class Simulation:
             ],
         )
         self.stops = {
-            stop_time.stop.stop_id: stop_time.stop
+            stop.stop_id: stop
             for trip in trips.values()
-            for stop_time in trip.stop_times
+            for stop in trip.stops
         }
 
     def start(self):

--- a/src/base_simulators/scheduled/simulation.py
+++ b/src/base_simulators/scheduled/simulation.py
@@ -19,9 +19,12 @@ class Simulation:
         self,
         start_time: datetime,
         capacity: int,
-        trips: typing.Dict[str, SingleTrip],
-        blocks: typing.Dict[str, list[SingleTrip]],
+        trips: typing.Dict[str, SingleTrip] = None,
+        blocks: typing.Dict[str, list[SingleTrip]] = None,
     ) -> None:
+        trips = trips or {}
+        blocks = blocks or {}
+
         self.env = Environment(start_time=start_time)
         self.event_queue = EventQueue()
         self.car_manager = CarManager(

--- a/src/base_simulators/scheduled/simulation.py
+++ b/src/base_simulators/scheduled/simulation.py
@@ -7,9 +7,9 @@ from datetime import datetime
 from logging import getLogger
 
 from environment import Environment
-from core import Trip
 from event import EventQueue, ReserveFailedEvent
 from mobility import CarManager, CarSetting
+from trip import SingleTrip, BlockTrip
 
 logger = getLogger(__name__)
 
@@ -19,20 +19,30 @@ class Simulation:
         self,
         start_time: datetime,
         capacity: int,
-        trips: typing.Dict[str, Trip],
+        trips: typing.Dict[str, SingleTrip],
+        blocks: typing.Dict[str, list[SingleTrip]],
     ) -> None:
         self.env = Environment(start_time=start_time)
         self.event_queue = EventQueue()
         self.car_manager = CarManager(
             env=self.env,
             event_queue=self.event_queue,
+            # ToDo: All trips may not have the same capacity.
             settings=[
                 CarSetting(
                     mobility_id=trip_id,
-                    capacity=capacity,  # ToDo: All trips may not have the same capacity.
+                    capacity=capacity,
                     trip=trip,
                 )
                 for trip_id, trip in trips.items()
+            ]
+            + [
+                CarSetting(
+                    mobility_id=block_id,
+                    capacity=capacity,
+                    trip=BlockTrip(trips=trips),
+                )
+                for block_id, trips in blocks.items()
             ],
         )
         self.stops = {

--- a/src/base_simulators/scheduled/simulation.py
+++ b/src/base_simulators/scheduled/simulation.py
@@ -36,9 +36,7 @@ class Simulation:
             ],
         )
         self.stops = {
-            stop.stop_id: stop
-            for trip in trips.values()
-            for stop in trip.stops
+            stop.stop_id: stop for trip in trips.values() for stop in trip.stops
         }
 
     def start(self):

--- a/src/base_simulators/scheduled/test/test_internal.py
+++ b/src/base_simulators/scheduled/test/test_internal.py
@@ -237,63 +237,65 @@ class BlockTripTestCase(unittest.TestCase):
             start_time=datetime.combine(self.reference_date, time()),
             capacity=20,
             trips={
-                self.mobility_id: BlockTrip(trips=[
-                    SingleTrip(
-                        route=...,
-                        service=Service(
-                            start_date=self.reference_date,
-                            end_date=self.reference_date + timedelta(days=7),
-                            monday=True,
-                            tuesday=True,
-                            wednesday=True,
-                            thursday=True,
-                            friday=False,
-                            saturday=False,
-                            sunday=False,
+                self.mobility_id: BlockTrip(
+                    trips=[
+                        SingleTrip(
+                            route=...,
+                            service=Service(
+                                start_date=self.reference_date,
+                                end_date=self.reference_date + timedelta(days=7),
+                                monday=True,
+                                tuesday=True,
+                                wednesday=True,
+                                thursday=True,
+                                friday=False,
+                                saturday=False,
+                                sunday=False,
+                            ),
+                            stop_times=[
+                                StopTime(
+                                    stop=self.stops[each[0]],
+                                    departure=timedelta(minutes=each[1]),
+                                )
+                                for each in [
+                                    ("3_1", 543),
+                                    ("7_1", 548),
+                                    ("11_1", 558),
+                                    ("15_1", 562),
+                                ]
+                            ],
+                            block_id="a",
                         ),
-                        stop_times=[
-                            StopTime(
-                                stop=self.stops[each[0]],
-                                departure=timedelta(minutes=each[1]),
-                            )
-                            for each in [
-                                ("3_1", 543),
-                                ("7_1", 548),
-                                ("11_1", 558),
-                                ("15_1", 562),
-                            ]
-                        ],
-                        block_id="a"
-                    ),
-                    SingleTrip(
-                        route=...,
-                        service=Service(
-                            start_date=self.reference_date,
-                            end_date=self.reference_date + timedelta(days=7),
-                            monday=False,
-                            tuesday=False,
-                            wednesday=False,
-                            thursday=True,
-                            friday=True,
-                            saturday=True,
-                            sunday=True,
+                        SingleTrip(
+                            route=...,
+                            service=Service(
+                                start_date=self.reference_date,
+                                end_date=self.reference_date + timedelta(days=7),
+                                monday=False,
+                                tuesday=False,
+                                wednesday=False,
+                                thursday=True,
+                                friday=True,
+                                saturday=True,
+                                sunday=True,
+                            ),
+                            stop_times=[
+                                StopTime(
+                                    stop=self.stops[each[0]],
+                                    departure=timedelta(minutes=each[1]),
+                                )
+                                for each in [
+                                    ("19_1", 566),
+                                    ("23_0", 574),
+                                    ("27_1", 578),
+                                    ("31_1", 583),
+                                    ("35_1", 590),
+                                ]
+                            ],
+                            block_id="a",
                         ),
-                        stop_times=[
-                            StopTime(
-                                stop=self.stops[each[0]],
-                                departure=timedelta(minutes=each[1]),
-                            )
-                            for each in [
-                                ("19_1", 566),
-                                ("23_0", 574),
-                                ("27_1", 578),
-                                ("31_1", 583),
-                                ("35_1", 590),
-                            ]
-                        ],
-                        block_id="a"
-                    ),
-                ]),
+                    ]
+                ),
             },
         )
         self.simulation.start()

--- a/src/base_simulators/scheduled/test/test_internal.py
+++ b/src/base_simulators/scheduled/test/test_internal.py
@@ -5,7 +5,8 @@ import logging
 from datetime import datetime, date, time, timedelta
 
 from simulation import Simulation
-from core import EventType, Stop, StopTime, Service, Trip
+from core import EventType, Stop, StopTime, Service
+from trip import SingleTrip, BlockTrip
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,7 @@ gtfs_stations = {
 }
 
 
-class SimpleTestCase(unittest.TestCase):
+class SingleTripTestCase(unittest.TestCase):
     def setUp(self) -> None:
         self.stops = gtfs_stations
         self.mobility_id = "mobility"
@@ -46,7 +47,7 @@ class SimpleTestCase(unittest.TestCase):
             start_time=datetime.combine(date.today(), time()),
             capacity=20,
             trips={
-                self.mobility_id: Trip(
+                self.mobility_id: SingleTrip(
                     route=...,
                     service=Service(
                         start_date=date.today(),
@@ -212,6 +213,240 @@ class SimpleTestCase(unittest.TestCase):
             {
                 "eventType": EventType.ARRIVED,
                 "time": 574.0,
+                "details": {
+                    "userId": user["user_id"],
+                    "mobilityId": self.mobility_id,
+                    "location": {
+                        "locationId": self.stops[user["dst"]].stop_id,
+                        "lat": self.stops[user["dst"]].lat,
+                        "lng": self.stops[user["dst"]].lng,
+                    },
+                },
+            },
+        ]
+        self.assertEqual(expected_events, triggered_events)
+
+
+class BlockTripTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.reference_date = date(year=2024, month=4, day=1)
+        self.stops = gtfs_stations
+        self.mobility_id = "mobility"
+
+        self.simulation = Simulation(
+            start_time=datetime.combine(self.reference_date, time()),
+            capacity=20,
+            trips={
+                self.mobility_id: BlockTrip(trips=[
+                    SingleTrip(
+                        route=...,
+                        service=Service(
+                            start_date=self.reference_date,
+                            end_date=self.reference_date + timedelta(days=7),
+                            monday=True,
+                            tuesday=True,
+                            wednesday=True,
+                            thursday=True,
+                            friday=False,
+                            saturday=False,
+                            sunday=False,
+                        ),
+                        stop_times=[
+                            StopTime(
+                                stop=self.stops[each[0]],
+                                departure=timedelta(minutes=each[1]),
+                            )
+                            for each in [
+                                ("3_1", 543),
+                                ("7_1", 548),
+                                ("11_1", 558),
+                                ("15_1", 562),
+                            ]
+                        ],
+                        block_id="a"
+                    ),
+                    SingleTrip(
+                        route=...,
+                        service=Service(
+                            start_date=self.reference_date,
+                            end_date=self.reference_date + timedelta(days=7),
+                            monday=False,
+                            tuesday=False,
+                            wednesday=False,
+                            thursday=True,
+                            friday=True,
+                            saturday=True,
+                            sunday=True,
+                        ),
+                        stop_times=[
+                            StopTime(
+                                stop=self.stops[each[0]],
+                                departure=timedelta(minutes=each[1]),
+                            )
+                            for each in [
+                                ("19_1", 566),
+                                ("23_0", 574),
+                                ("27_1", 578),
+                                ("31_1", 583),
+                                ("35_1", 590),
+                            ]
+                        ],
+                        block_id="a"
+                    ),
+                ]),
+            },
+        )
+        self.simulation.start()
+
+    def test_cannot_reserve_the_second_trip_only_the_first_trip_is_operating(self):
+        user = {
+            "user_id": "U_001",
+            "org": "3_1",
+            "dst": "23_0",
+            "dept": 490,  # Monday
+        }
+        run(self.simulation, until=user["dept"])
+
+        self.simulation.reserve_user(
+            user_id=user["user_id"],
+            org=user["org"],
+            dst=user["dst"],
+            dept=user["dept"],
+        )
+        triggered_events = run(self.simulation, until=user["dept"] + 1)
+
+        expected_events = [
+            {
+                "eventType": EventType.RESERVED,
+                "time": user["dept"],
+                "details": {
+                    "success": False,
+                    "userId": user["user_id"],
+                },
+            }
+        ]
+        self.assertEqual(expected_events, triggered_events)
+
+    def test_can_reserve_the_first_trip_only_the_first_trip_is_operating(self):
+        user = {
+            "user_id": "U_001",
+            "org": "3_1",
+            "dst": "11_1",
+            "dept": 490,  # Monday
+        }
+        run(self.simulation, until=user["dept"])
+
+        self.simulation.reserve_user(
+            user_id=user["user_id"],
+            org=user["org"],
+            dst=user["dst"],
+            dept=user["dept"],
+        )
+        triggered_events = run(self.simulation, until=user["dept"] + 1)
+
+        expected_events = [
+            {
+                "eventType": EventType.RESERVED,
+                "time": user["dept"],
+                "details": {
+                    "success": True,
+                    "userId": user["user_id"],
+                    "mobilityId": self.mobility_id,
+                    "route": [
+                        {
+                            "org": {
+                                "locationId": self.stops[user["org"]].stop_id,
+                                "lat": self.stops[user["org"]].lat,
+                                "lng": self.stops[user["org"]].lng,
+                            },
+                            "dst": {
+                                "locationId": self.stops[user["dst"]].stop_id,
+                                "lat": self.stops[user["dst"]].lat,
+                                "lng": self.stops[user["dst"]].lng,
+                            },
+                            "dept": 543.0,
+                            "arrv": 558.0,
+                        }
+                    ],
+                },
+            }
+        ]
+        self.assertEqual(expected_events, triggered_events)
+
+    def test_a_user_flow_both_trips_are_in_operation(self):
+        thursday = 1440 * 3
+        user = {
+            "user_id": "U_001",
+            "org": "3_1",
+            "dst": "23_0",
+            "dept": thursday + 490,  # Thursday
+        }
+        run(self.simulation, until=user["dept"])
+
+        self.simulation.reserve_user(
+            user_id=user["user_id"],
+            org=user["org"],
+            dst=user["dst"],
+            dept=user["dept"],
+        )
+
+        triggered_events = run(self.simulation, until=user["dept"] + 1)
+
+        expected_events = [
+            {
+                "eventType": EventType.RESERVED,
+                "time": user["dept"],
+                "details": {
+                    "success": True,
+                    "userId": user["user_id"],
+                    "mobilityId": self.mobility_id,
+                    "route": [
+                        {
+                            "org": {
+                                "locationId": self.stops[user["org"]].stop_id,
+                                "lat": self.stops[user["org"]].lat,
+                                "lng": self.stops[user["org"]].lng,
+                            },
+                            "dst": {
+                                "locationId": self.stops[user["dst"]].stop_id,
+                                "lat": self.stops[user["dst"]].lat,
+                                "lng": self.stops[user["dst"]].lng,
+                            },
+                            "dept": thursday + 543.0,
+                            "arrv": thursday + 574.0,
+                        }
+                    ],
+                },
+            }
+        ]
+        self.assertEqual(expected_events, triggered_events)
+
+        self.simulation.dept_user(
+            user_id=user["user_id"],
+        )
+
+        triggered_events = run(self.simulation, until=thursday + 574.1)
+        triggered_events = [
+            event for event in triggered_events if event["details"]["userId"]
+        ]
+
+        expected_events = [
+            {
+                "eventType": EventType.DEPARTED,
+                "time": thursday + 543.0,
+                "details": {
+                    "userId": user["user_id"],
+                    "mobilityId": self.mobility_id,
+                    "location": {
+                        "locationId": self.stops[user["org"]].stop_id,
+                        "lat": self.stops[user["org"]].lat,
+                        "lng": self.stops[user["org"]].lng,
+                    },
+                },
+            },
+            {
+                "eventType": EventType.ARRIVED,
+                "time": thursday + 574.0,
                 "details": {
                     "userId": user["user_id"],
                     "mobilityId": self.mobility_id,

--- a/src/base_simulators/scheduled/trip.py
+++ b/src/base_simulators/scheduled/trip.py
@@ -21,10 +21,7 @@ class SingleTrip(Trip):
 
     @property
     def stops(self) -> typing.List[Stop]:
-        return [
-            stop_time.stop
-            for stop_time in self.stop_times
-        ]
+        return [stop_time.stop for stop_time in self.stop_times]
 
     def is_operation(self, at: date) -> bool:
         return self.service.is_operation(at)
@@ -69,17 +66,10 @@ class BlockTrip(Trip):
 
     @property
     def stops(self) -> typing.List[Stop]:
-        return [
-            stop_time.stop
-            for trip in self.trips
-            for stop_time in trip.stop_times
-        ]
+        return [stop_time.stop for trip in self.trips for stop_time in trip.stop_times]
 
     def is_operation(self, at: date) -> bool:
-        return any([
-            trip.service.is_operation(at)
-            for trip in self.trips
-        ])
+        return any([trip.service.is_operation(at) for trip in self.trips])
 
     def stop_times_at(self, at: date):
         # Depending on the service configuration, a block trip can be split into multiple trips

--- a/src/base_simulators/scheduled/trip.py
+++ b/src/base_simulators/scheduled/trip.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
+# SPDX-License-Identifier: Apache-2.0
+import typing
+import dataclasses
+from datetime import date
+
+from core import Trip, Route, Service, StopTime, Stop, StopTimeWithDateTime, Path
+
+
+@dataclasses.dataclass(frozen=True)
+class SingleTrip(Trip):
+    """Sequence of two or more stops that occur during a specific time period."""
+
+    route: Route
+    service: Service
+    stop_times: typing.List[StopTime]
+    block_id: str
+
+    def __post_init__(self):
+        assert len(self.stop_times) >= 2
+
+    @property
+    def stops(self) -> typing.List[Stop]:
+        return [
+            stop_time.stop
+            for stop_time in self.stop_times
+        ]
+
+    def is_operation(self, at: date) -> bool:
+        return self.service.is_operation(at)
+
+    def stop_times_at(self, at_date: date):
+        return [
+            StopTimeWithDateTime(stop_time=stop_time, reference_date=at_date)
+            for stop_time in self.stop_times
+        ]
+
+    def start_time(self, at: date):
+        return list(self.stop_times_at(at))[0].arrival
+
+    def end_time(self, at: date):
+        return list(self.stop_times_at(at))[-1].departure
+
+    def paths(self, org: Stop, dst: Stop, at: date):
+        if not self.service.is_operation(at):
+            return
+
+        for stop_time_org in self.stop_times_at(at):
+            if stop_time_org.stop == org:
+                for stop_time_dst in self.stop_times_at(at):
+                    if (
+                        stop_time_dst.stop == dst
+                        and stop_time_org.departure < stop_time_dst.arrival
+                    ):
+                        yield Path(pick_up=stop_time_org, drop_off=stop_time_dst)
+
+
+@dataclasses.dataclass(frozen=True)
+class BlockTrip(Trip):
+    """Sequence of trips which belong to a block"""
+
+    route: Route
+    service: Service
+    trips: typing.List[SingleTrip]
+
+    def __post_init__(self):
+        assert len(self.trips) >= 2
+        assert len(set(trip.block_id for trip in self.trips)) <= 1
+        assert self.trips[0].block_id != ""
+
+    @property
+    def stops(self) -> typing.List[Stop]:
+        raise NotImplementedError()
+
+    def is_operation(self, at_date: date) -> bool:
+        raise NotImplementedError()
+
+    def stop_times_at(self, at_date: date):
+        raise NotImplementedError()
+
+    def start_time(self, at: date):
+        raise NotImplementedError()
+
+    def end_time(self, at: date):
+        raise NotImplementedError()
+
+    def paths(self, org: Stop, dst: Stop, at: date):
+        raise NotImplementedError()


### PR DESCRIPTION
I have divided `Trip` into two concrete trips, `SingleTrip` and `BlockTrip`, where `SingleTrip` is no different from the original Trip. A Trip is an itinerary operated by a single mobility service that allows passengers to board in succession. This also remains.

A `SingleTrip` is only associated with a single `Service`.
A `BlockTrip` always consists of two or more `SingleTrip`s with the same `block_id`, i.e., A `BlockTrip` is associated with multiple `Service`s. Therefore, a BlockTrip's itinerary can change depending on the day of the week or the date.

> [!WARNING]  
> Only relatively simple BlockTrips are supported.

It is possible to combine three or more services to create a complex BlockTrip with different days of the week, but I do not regard this as practical.