### PR TITLE
bugfix: Sequence of `SingleTrip`s constituting a Block

### DIFF
--- a/src/base_simulators/scheduled/simulation.py
+++ b/src/base_simulators/scheduled/simulation.py
@@ -43,7 +43,7 @@ class Simulation:
                 CarSetting(
                     mobility_id=block_id,
                     capacity=capacity,
-                    trip=BlockTrip(trips=trips),
+                    trip=BlockTrip(trips=sorted(trips, key=lambda x: x.stop_times[0].departure)),
                 )
                 for block_id, trips in blocks.items()
             ],

--- a/src/base_simulators/scheduled/simulation.py
+++ b/src/base_simulators/scheduled/simulation.py
@@ -43,7 +43,9 @@ class Simulation:
                 CarSetting(
                     mobility_id=block_id,
                     capacity=capacity,
-                    trip=BlockTrip(trips=sorted(trips, key=lambda x: x.stop_times[0].departure)),
+                    trip=BlockTrip(
+                        trips=sorted(trips, key=lambda x: x.stop_times[0].departure)
+                    ),
                 )
                 for block_id, trips in blocks.items()
             ],

--- a/src/base_simulators/scheduled/trip.py
+++ b/src/base_simulators/scheduled/trip.py
@@ -63,6 +63,9 @@ class BlockTrip(Trip):
         assert len(self.trips) >= 2
         assert len(set(trip.block_id for trip in self.trips)) <= 1
         assert self.trips[0].block_id != ""
+        
+        # The following assertion is generally true for most cases,
+        assert self.trips[0].stop_times[0].departure < self.trips[1].stop_times[0].departure
 
     @property
     def stops(self) -> typing.List[Stop]:

--- a/src/base_simulators/scheduled/trip.py
+++ b/src/base_simulators/scheduled/trip.py
@@ -63,9 +63,12 @@ class BlockTrip(Trip):
         assert len(self.trips) >= 2
         assert len(set(trip.block_id for trip in self.trips)) <= 1
         assert self.trips[0].block_id != ""
-        
+
         # The following assertion is generally true for most cases,
-        assert self.trips[0].stop_times[0].departure < self.trips[1].stop_times[0].departure
+        assert (
+            self.trips[0].stop_times[0].departure
+            < self.trips[1].stop_times[0].departure
+        )
 
     @property
     def stops(self) -> typing.List[Stop]:


### PR DESCRIPTION
`BlockTrip` consists of `SingleTrip` arranged in ascending order of time.

In GTFS, the sequence of `SingleTrip` descriptions is arbitrary, so we needed to reorder them accordingly. In more complex blocks, they might not necessarily follow this order, but for now, we've chosen a compromise in the implementation.