### PR TITLE
Bugfix/otp planner missing permissions

### DIFF
--- a/src/planner/opentripplanner/Dockerfile
+++ b/src/planner/opentripplanner/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.11-slim
 
-
 RUN apt-get update && apt-get install -y \
     openjdk-17-jre \
     wget \
@@ -16,6 +15,8 @@ ENV PIP_ROOT_USER_ACTION=ignore
 RUN pip install --upgrade pip \
  && pip install --upgrade setuptools \
  && pip install -r requirements.txt
+
+RUN chown nobody -R /var/otp
 
 USER nobody
 

--- a/src/planner/opentripplanner/config.py
+++ b/src/planner/opentripplanner/config.py
@@ -13,6 +13,7 @@ class Configuration(LogConfig, frozen=True):
     )
     FILE_SIZE_LIMIT: int = 0  # file size limit for each input file
     # data directory for OpenTripPlanner core
+    OPENTRIPPLANNER_EXECUTABLE: pathlib.Path = pathlib.Path("/var/otp/otp-shaded.jar")
     OPENTRIPPLANNER_VOLUME_DIR: pathlib.Path = pathlib.Path("/var/otp/volume")
     OPENTRIPPLANNER_GBFS_DIR: pathlib.Path = pathlib.Path("/var/otp/volume/gbfs")
 

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -225,7 +225,7 @@ async def setup(request: fastapi.Request, setting: query.Setup):
         "java",
         "-Xmx5G",
         "-jar",
-        "/var/otp/otp-shaded.jar",
+        str(env.OPENTRIPPLANNER_EXECUTABLE),
         "--build",
         "--port",
         str(env.OPENTRIPPLANNER_PORT),

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -17,7 +17,7 @@ import aiohttp
 import fastapi
 
 from config import env
-from core import Location
+from core import Location, Path
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
@@ -258,10 +258,10 @@ async def meters_for_all_stops_combinations(stops: list[str]):
     return await planner.meters_for_all_stops_combinations(stops, planner.ref_datetime)
 
 
-# `response_model=list[Path]` does not work
-# @app.post("/plan", response_model=list[Path])
-@app.post("/plan")
+@app.post("/plan", response_model=list[Path])
 async def plan(org: query.LocationSetting, dst: query.LocationSetting, dept: float):
     org = Location(id_=org.locationId, lat=org.lat, lng=org.lng)
     dst = Location(id_=dst.locationId, lat=dst.lat, lng=dst.lng)
-    return await planner.plan(org, dst, dept)
+    plans = await planner.plan(org, dst, dept)
+    print(plans)
+    return plans

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -254,7 +254,8 @@ async def planner_up(interval: float):
 
 
 @app.post("/matrix", response_model=response.DistanceMatrix)
-async def meters_for_all_stops_combinations(stops: list[str]):
+async def meters_for_all_stops_combinations(stops: list[query.LocationSetting]):
+    stops = [stop.locationId for stop in stops]
     return await planner.meters_for_all_stops_combinations(stops, planner.ref_datetime)
 
 

--- a/src/user_model/simple/planner.py
+++ b/src/user_model/simple/planner.py
@@ -15,7 +15,7 @@ class Planner:
         await self._session.close()
 
     async def plan(self, org: Location, dst: Location, dept: float) -> list[Route]:
-        response = self.query(org, dst, dept)
+        response = await self.query(org, dst, dept)
         return [
             Route(
                 [
@@ -37,7 +37,7 @@ class Planner:
                     for trip in route["trips"]
                 ]
             )
-            for route in await response
+            for route in response
         ]
 
     async def query(self, org: Location, dst: Location, dept: float):


### PR DESCRIPTION
## Permission error
I found a bug in the otpplanner module where a `PermissionError` occurs when attempting to access the `/var/otp/volume` directory:

```console
PermissionError: [Errno 13] Permission denied: '/var/otp/volume'
```

The error arises because the container's `nobody` user does not have the necessary permissions to access the `/var/otp/volume` directory. To fix this, I have added a command to change the ownership of the `/var/otp` directory to the `nobody` user. The following line has been added to the Dockerfile:

```Dockerfile
RUN chown nobody -R /var/otp
```

## Inconsistent `/matrix` endpoint

I have found the argument for the `/matrix` endpoint of otpplanner was not the correct `list[query.LocationSetting]` type, but `list[str]`.

I have modified the `/matrix` endpoint to accept `list[query.LocationSetting]`, aligning it with the simpleplanner. While otpplanner can calculate distances using `str` (stop_id), for consistency across planner interfaces, it is desirable to accept list[query.LocationSetting].

## OTP path configuration

Additionally, I have added functionality to allow the OTP executable path to be configurable.