### PR TITLE
Feature/pre-reserve ondemand mobility

### DIFF
--- a/ci/scheduled-historical/broker_setup.json
+++ b/ci/scheduled-historical/broker_setup.json
@@ -26,11 +26,11 @@
             "lat": 36.6835921,
             "lng": 137.2044729
           },
+          "time": 540.0,
           "dept": 540.0
         }
       ],
-      "userIDFormat": "U_%d",
-      "offset_time": 0
+      "userIDFormat": "U_%d"
     }
   },
   "gtfs": {

--- a/src/base_simulators/ondemand/controller.py
+++ b/src/base_simulators/ondemand/controller.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
+import json
 import io
 import logging
 import zipfile
@@ -97,6 +98,20 @@ async def setup(settings: query.Setup):
                         continue
                     assert (
                         distance >= 0
+                    ), f"distance must not negative: {distance}, {stop_a} -> {stop_b}"
+                    network.add_edge(stop_a, stop_b, distance / settings.mobility_speed)
+        elif network_filename := settings.network.filename:
+            _, data = await file_table.pop(
+                session, filename=network_filename, url=None
+            )
+            matrix = json.loads(data)
+            network = Network()
+            for stop_a, row in zip(matrix["stops"], matrix["matrix"]):
+                for stop_b, distance in zip(matrix["stops"], row):
+                    if stop_a == stop_b:
+                        continue
+                    assert (
+                            distance >= 0
                     ), f"distance must not negative: {distance}, {stop_a} -> {stop_b}"
                     network.add_edge(stop_a, stop_b, distance / settings.mobility_speed)
         else:

--- a/src/base_simulators/ondemand/controller.py
+++ b/src/base_simulators/ondemand/controller.py
@@ -101,9 +101,7 @@ async def setup(settings: query.Setup):
                     ), f"distance must not negative: {distance}, {stop_a} -> {stop_b}"
                     network.add_edge(stop_a, stop_b, distance / settings.mobility_speed)
         elif network_filename := settings.network.filename:
-            _, data = await file_table.pop(
-                session, filename=network_filename, url=None
-            )
+            _, data = await file_table.pop(session, filename=network_filename, url=None)
             matrix = json.loads(data)
             network = Network()
             for stop_a, row in zip(matrix["stops"], matrix["matrix"]):
@@ -111,7 +109,7 @@ async def setup(settings: query.Setup):
                     if stop_a == stop_b:
                         continue
                     assert (
-                            distance >= 0
+                        distance >= 0
                     ), f"distance must not negative: {distance}, {stop_a} -> {stop_b}"
                     network.add_edge(stop_a, stop_b, distance / settings.mobility_speed)
         else:

--- a/src/base_simulators/walking/simulation.py
+++ b/src/base_simulators/walking/simulation.py
@@ -10,7 +10,7 @@ from core import Location
 from event import ReservedEvent, DepartedEvent, ArrivedEvent
 
 logger = logging.getLogger(__name__)
-MIN_DURATION = 0.1  # = 6秒
+MIN_DURATION = 0.0
 
 
 @dataclass(frozen=True)

--- a/src/scenario/historical/controller.py
+++ b/src/scenario/historical/controller.py
@@ -54,7 +54,6 @@ def setup(settings: query.Setup):
         settings.trips,
         settings.userIDFormat,
         settings.demandIDFormat,
-        settings.offset_time,
     )
     return response.Message(message="successfully configured.")
 

--- a/src/scenario/historical/core.py
+++ b/src/scenario/historical/core.py
@@ -24,6 +24,7 @@ class DemandInfo:
 
     org: Location
     dst: Location
+    dept: float
     service: str | None
     demand_id: str
     user_type: str | None
@@ -42,6 +43,7 @@ class DemandEvent:
                 "userId": self.user_id,
                 "userType": self.info.user_type,
                 "demandId": self.info.demand_id,
+                "dept": self.info.dept,
                 "org": {
                     "locationId": info.org.location_id,
                     "lat": info.org.lat,

--- a/src/scenario/historical/jschema/query.py
+++ b/src/scenario/historical/jschema/query.py
@@ -12,6 +12,7 @@ class LocationSetting(BaseModel):
 class HistoricalDemandSetting(BaseModel):
     org: LocationSetting
     dst: LocationSetting
+    time: float = Field(..., description="Time to reserve mobilities")
     dept: float = Field(..., description="Time to start move from org to dst")
     service: str | None = None
     user_id: str | None = None
@@ -29,4 +30,3 @@ class Setup(BaseModel):
     trips: list[HistoricalDemandSetting]
     userIDFormat: str = "U_%d"
     demandIDFormat: str = "D_%d"
-    offset_time: float = 0.0

--- a/src/scenario/historical/test/test_scenario.py
+++ b/src/scenario/historical/test/test_scenario.py
@@ -34,6 +34,7 @@ class HistoricalScenarioTestCase(unittest.TestCase):
                     dst=jschema.query.LocationSetting(
                         locationId=dst["locationId"], lat=dst["lat"], lng=dst["lng"]
                     ),
+                    time=400.0,
                     dept=400.0,
                     service="mobility",
                     user_type="user-xyz",

--- a/src/scenario/historical/test/test_scenario.py
+++ b/src/scenario/historical/test/test_scenario.py
@@ -52,6 +52,7 @@ class HistoricalScenarioTestCase(unittest.TestCase):
                     "userId": "U_1",
                     "userType": "user-xyz",
                     "demandId": "D_1",
+                    "dept": 400,
                     "org": org,
                     "dst": dst,
                     "service": "mobility",


### PR DESCRIPTION
Previously, the reservation time was always set to be the same as the departure time.
Now, reservation time (`time` field) and departure time (`dept` field) are separate values. This change supports a scenario in which reservations are made well in advance, as is often the case with on-demand services.
The `off_set` mechanism, which allowed reservations to be made earlier than the departure time by a fixed offset, has been removed.

It is now possible to specify reservation times, such as "midnight," providing more flexibility in defining reservation behavior. As a result, creating historical demand settings now requires specifying reservation times separately, which adds a small amount of complexity.