### PR TITLE
Allow the departure time of the shortest route to be equal to the current time

### DIFF
--- a/src/base_simulators/scheduled/mobility.py
+++ b/src/base_simulators/scheduled/mobility.py
@@ -172,7 +172,7 @@ class Car(Mobility):
             self.paths(org, dst, at=dept_datetime.date() + timedelta(days=1)),
         ):
             # This route is available for boarding.
-            if dept_datetime < path.departure:
+            if dept_datetime <= path.departure:
                 return path
         return None
 


### PR DESCRIPTION
In the logic for finding the shortest route, only routes that allow passengers to board are specifically chosen. The condition is that the departure time must be later than the current time.

For direct routes using `block_id`, the arrival time and departure time may be the same. Therefore, the logic must be modified so that the departure time of the route is **the same as or later than** the current time.