### PR TITLE
Migrate OTP Planner API from REST to GraphQL

### DIFF
--- a/ci/allowed-license.lst
+++ b/ci/allowed-license.lst
@@ -1,6 +1,7 @@
 # These license names are used for pip-license (https://github.com/raimon49/pip-licenses) and must use same word presented in pip license information.
 # We identified a line with non-alphabetical characters in head as comment.
 MIT License
+MIT
 BSD License
 Apache-2.0
 Apache Software License

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -251,7 +251,12 @@ async def setup(request: fastapi.Request, setting: query.Setup):
         endpoint=f"http://localhost:{env.OPENTRIPPLANNER_PORT}",
         ref_datetime=ref_datetime,
         walking_meters_per_minute=walking_meters_per_minute,
-        transport_modes=[[{"mode": mode.mode, "qualifier": mode.qualifier} for mode in modes.modes] for modes in setting.modes] if setting.modes else None,
+        transport_modes=[
+            [{"mode": mode.mode, "qualifier": mode.qualifier} for mode in modes.modes]
+            for modes in setting.modes
+        ]
+        if setting.modes
+        else None,
         services={
             details.agency_id or service: service
             for service, details in setting.networks.items()
@@ -309,12 +314,23 @@ async def plan(org: query.LocationSetting, dst: query.LocationSetting, dept: flo
 @app.get("/graphiql")
 async def graphiql():
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"http://localhost:{env.OPENTRIPPLANNER_PORT}/graphiql") as resp:
-            return fastapi.Response(content=await resp.read(), status_code=resp.status, headers=dict(resp.headers))
+        async with session.get(
+            f"http://localhost:{env.OPENTRIPPLANNER_PORT}/graphiql"
+        ) as resp:
+            return fastapi.Response(
+                content=await resp.read(),
+                status_code=resp.status,
+                headers=dict(resp.headers),
+            )
 
 
 @app.post("/otp/routers/default/index/graphql")
 async def graphql(request: fastapi.Request):
     async with aiohttp.ClientSession() as session:
-        async with session.post(f"http://localhost:{env.OPENTRIPPLANNER_PORT}/otp/routers/default/index/graphql", json=await request.json()) as resp:
-            return fastapi.responses.JSONResponse(content=await resp.json(), status_code=resp.status)
+        async with session.post(
+            f"http://localhost:{env.OPENTRIPPLANNER_PORT}/otp/routers/default/index/graphql",
+            json=await request.json(),
+        ) as resp:
+            return fastapi.responses.JSONResponse(
+                content=await resp.json(), status_code=resp.status
+            )

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -251,7 +251,7 @@ async def setup(request: fastapi.Request, setting: query.Setup):
         endpoint=f"http://localhost:{env.OPENTRIPPLANNER_PORT}",
         ref_datetime=ref_datetime,
         walking_meters_per_minute=walking_meters_per_minute,
-        modes=setting.modes,
+        transport_modes=[[{"mode": mode.mode, "qualifier": mode.qualifier} for mode in modes.modes] for modes in setting.modes] if setting.modes else None,
         services={
             details.agency_id or service: service
             for service, details in setting.networks.items()
@@ -304,3 +304,17 @@ async def plan(org: query.LocationSetting, dst: query.LocationSetting, dept: flo
     plans = await planner.plan(org, dst, dept)
     print(plans)
     return plans
+
+
+@app.get("/graphiql")
+async def graphiql():
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"http://localhost:{env.OPENTRIPPLANNER_PORT}/graphiql") as resp:
+            return fastapi.Response(content=await resp.read(), status_code=resp.status, headers=dict(resp.headers))
+
+
+@app.post("/otp/routers/default/index/graphql")
+async def graphql(request: fastapi.Request):
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"http://localhost:{env.OPENTRIPPLANNER_PORT}/otp/routers/default/index/graphql", json=await request.json()) as resp:
+            return fastapi.responses.JSONResponse(content=await resp.json(), status_code=resp.status)

--- a/src/planner/opentripplanner/jschema/query.py
+++ b/src/planner/opentripplanner/jschema/query.py
@@ -38,11 +38,20 @@ class NetworkSetting(BaseModel):
     agency_id: str | None = None  # equivalent to system_id for GBFS file
 
 
+class TransportMode(BaseModel):
+    mode: str
+    qualifier: str | None = None
+
+
+class TransportModes(BaseModel):
+    modes: conlist(TransportMode, min_length=1)
+
+
 class Setup(BaseModel):
     otp_config: OTPDetails
     networks: dict[str, NetworkSetting]
     reference_time: constr(min_length=8, max_length=8)
-    modes: conlist(str, min_length=1) = ["TRANSIT,WALK", "FLEX_DIRECT,WALK"]
+    modes: conlist(TransportModes, min_length=1) = None
     walking_meters_per_minute: float | None = (
         None  # get from router_config.json, if None
     )

--- a/src/planner/opentripplanner/requirements.txt
+++ b/src/planner/opentripplanner/requirements.txt
@@ -1,6 +1,7 @@
 aiohttp~=3.8.5
 fastapi~=0.103.2
 geopy~=2.4.0
+gql[all]~=3.5.0
 pydantic~=2.4.2
 pydantic_settings~=2.0.3
 python-multipart~=0.0.5

--- a/src/planner/opentripplanner/route_planner.py
+++ b/src/planner/opentripplanner/route_planner.py
@@ -5,8 +5,9 @@ import datetime
 import logging
 import re
 import typing
-import pprint
 
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
 import aiohttp
 
 from core import Location, Path, Trip, calc_distance
@@ -14,47 +15,11 @@ from jschema.response import DistanceMatrix
 from mblib.io import httputil
 
 logger = logging.getLogger(__name__)
-
-
-class AsyncClient:
-    def __init__(self, endpoint: str):
-        self._endpoint = endpoint
-        self._session = aiohttp.ClientSession()
-        self._semaphore = asyncio.Semaphore(8)
-
-    async def get(
-        self,
-        method: str,
-        params: typing.Mapping[str, str] = None,
-        *,
-        suppress_log=False,
-    ):
-        url = self._endpoint + "/" + method
-        async with self._semaphore:
-            async with self._session.get(url, params=params) as response:
-                await httputil.check_response(response)
-                if not suppress_log:
-                    logger.debug("%s response: %s", url, await response.text())
-                return await response.json()
-
-    async def close(self):
-        await self._session.close()
-
-
 pattern = re.compile(r".+:(.*)")
 
 
-def get_id_from_dict(raw: typing.Mapping, key: str, *keys: str) -> str:
-    """Get id or name"""
-    if value := raw.get(key):
-        # remove prefix for unique descent across the GTFSs
-        return pattern.match(value).groups()[0]
-    else:
-        for key in keys:
-            if value := raw.get(key):
-                return value
-        else:
-            raise KeyError(key)
+def id_from_gtfs_id(gtfs_id: str) -> str:
+    return pattern.match(gtfs_id).groups()[0]
 
 
 class OpenTripPlanner:
@@ -63,20 +28,30 @@ class OpenTripPlanner:
         endpoint: str,
         ref_datetime: datetime.datetime,
         walking_meters_per_minute: float,
-        modes: list[str],
+        transport_modes: list[list[typing.Mapping]],
         services: typing.Mapping[str, str],
     ):
         super().__init__()
-        self.client = AsyncClient(endpoint)
+        self.endpoint = endpoint
+        self.client = Client(
+            transport=AIOHTTPTransport(url=f"{endpoint}/otp/routers/default/index/graphql"),
+            fetch_schema_from_transport=True,
+        )
         self.ref_datetime = ref_datetime
         self.walking_velocity = walking_meters_per_minute
-        self.modes = modes
-        self.services = services  # key: agency_id, value: service名
+        self.transport_modes = transport_modes if transport_modes else [[
+            {"mode": "WALK"},
+            {"mode": "TRANSIT"},
+        ], [
+            {"mode": "WALK"},
+            {"mode": "FLEX", "qualifier": "DIRECT"}
+        ]]
+        self.services = services  # key: agency_id, value: service name
 
         # ToDo: overwrite otp default walking velocity to self.walking_velocity
 
     async def close(self):
-        await self.client.close()
+        await self.client.close_async()
 
     def _elapsed(self, timestamp: str):
         return (
@@ -86,87 +61,52 @@ class OpenTripPlanner:
 
     async def health(self):
         try:
-            response = await self.client.get("otp/actuators/health")
-            return response == {"status": "UP"}
+            async with aiohttp.ClientSession() as session:
+                async with session.get(f"{self.endpoint}/otp/actuators/health") as resp:
+                    result = await resp.json()
+            return result == {"status": "UP"}
         except aiohttp.ClientConnectionError:
             return False
 
     async def meters_for_all_stops_combinations(
         self, stops: list[str], base: datetime.datetime
     ):
-        failed_stops = set()
+        stops_org = stops
         stop_id_map = {
-            get_id_from_dict(e, "id"): e["id"]
-            for e in await self.client.get(method="otp/routers/default/index/stops")
+            id_from_gtfs_id(stop["gtfsId"]): stop["gtfsId"]
+            for stop in await self.stops()
         }
-
-        async def _distance(org: str, dst: str):
-            org_id = stop_id_map.get(org)
-            dst_id = stop_id_map.get(dst)
-            if org_id is None or dst_id is None:
-                return -1
-            if org_id == dst_id:
-                return 0
-            if org_id in failed_stops or dst_id in failed_stops:
-                return -1
-
-            try:
-                response = await self.client.get(
-                    method="otp/routers/default/plan",
-                    params={
-                        "mode": "CAR",
-                        "fromPlace": org_id,
-                        "toPlace": dst_id,
-                        "time": f"{base.time()}",
-                        "date": f"{base.date()}",
-                    },
-                    suppress_log=True,
-                )
-                assert "plan" in response, f"no plan in response: {response}"
-                if not response["plan"]["itineraries"]:
-                    return 0
-                distance = response["plan"]["itineraries"][0]["walkDistance"]
-                if distance < 0:
-                    logger.error("illegal response from OTP: %s", response)
-                    raise ValueError(
-                        "illegal response from OTP, distance = %s", distance
-                    )
-                return distance
-            except Exception as e:
-                logger.warning(
-                    f"failed to calculate the distance between {org} and {dst}. Error: {e}."
-                )
-                failed_stops.add(dst)
-                return -1
+        stops = [stop_id_map[stop] for stop in stops]
 
         matrix: list[list[float]] = []
-        for stop_a in stops:
-            vals = await asyncio.gather(
-                *[_distance(org=stop_a, dst=stop_b) for stop_b in stops]
-            )
-            matrix.append(list(vals))
-        return DistanceMatrix(stops=stops, matrix=matrix)
+        async with self.client as session:
+            for stop_a in stops:
+                vals = await asyncio.gather(
+                    *[self.distance(session, org=stop_a, dst=stop_b, date=f"{base.date()}", time=f"{base.time()}") for stop_b in stops]
+                )
+                matrix.append(list(vals))
+        return DistanceMatrix(stops=stops_org, matrix=matrix)
 
     async def plan(self, org: Location, dst: Location, dept: float) -> list[Path]:
         paths: list[Path] = []
-        for mode in self.modes:
-            async for path in self._plan(mode=mode, org=org, dst=dst, dept=dept):
+        for modes in self.transport_modes:
+            async for path in self._plan_query(modes=modes, org=org, dst=dst, dept=dept):
                 if path not in paths:  # ignore duplicated walking path
                     paths.append(path)
         paths.sort(key=lambda e: e.arrv)
-        if not any(
-            all(trip.service == "walking" for trip in path.trips) for path in paths
-        ):
-            # ToDo: Discuss again who should determine the means of transit if no route can be found.
-            # If any routes are not found, return the walking route.
-            walk_path = self.get_walk_path(org, dst, dept)
-            logger.warning("no plan by OTP, and return walk path: %s", walk_path)
-            paths.append(walk_path)
+
+        if not paths:
+            logger.warning("no plan by OTP, and return straight walk path.")
+            return [self.straight_walk_path(org, dst, dept)]
+
+        if all(all(trip.service == "walking" for trip in path.trips) for path in paths):
+            logger.warning("no service plan by OTP, and return walk path")
+
         return paths
 
-    def get_walk_path(self, org: Location, dst: Location, dept: float) -> Path:
+    def straight_walk_path(self, org: Location, dst: Location, dept: float) -> Path:
         return Path(
-            [
+            trips=[
                 Trip(
                     org=org,
                     dst=dst,
@@ -178,76 +118,135 @@ class OpenTripPlanner:
             walking_time_minutes=calc_distance(org, dst) / self.walking_velocity,
         )
 
-    async def _plan(self, mode: str, org: Location, dst: Location, dept: float):
+    async def stops(self) -> list[typing.Mapping[str, str]]:
+        query = gql("""
+        query Stops {
+          stops {
+            gtfsId
+          }
+        }
+        """)
+
+        response = await self.client.execute_async(query)
+        return response["stops"]
+
+    async def distance(self, session, org: str, dst: str, date: str, time: str) -> int:
+        query = gql("""
+        query PlanQuery($from: String, $to: String, $date: String, $time: String) {
+          plan(
+            fromPlace: $from
+            toPlace: $to
+            date: $date
+            time: $time
+            transportModes: [{ mode: CAR }]
+            numItineraries: 1
+            maxTransfers: 1
+          ) {
+            itineraries {
+              walkDistance 
+            }
+          }
+        }
+        """)
+
+        response = await session.execute(query, variable_values={
+            "date": date,
+            "time": time,
+            "from": org,
+            "to": dst,
+        })
+
+        if response['plan']['itineraries']:
+            return response['plan']['itineraries'][0]["walkDistance"]
+        else:
+            return 0
+
+    async def _plan_query(self, modes: list[typing.Mapping], org: Location, dst: Location, dept: float):
+        query = gql("""
+    query PlanQuery($modes: [TransportMode], $from: InputCoordinates, $to: InputCoordinates, $date: String, $time: String) {
+      plan(
+        from: $from
+        to: $to
+        date: $date
+        time: $time
+        transportModes: $modes
+        numItineraries: 3
+        maxTransfers: 4
+      ) {
+        itineraries {
+          walkTime
+          legs {
+            mode
+            agency {
+              gtfsId
+            }
+            from {
+              name
+              lat
+              lon
+              stop {
+                gtfsId
+              }
+              departureTime
+            }
+            to {
+              name
+              lat
+              lon
+              stop {
+                gtfsId
+              }
+              arrivalTime
+            }
+          }
+        }
+      }
+    }
+            """)
+
         dept_datetime = self.ref_datetime + datetime.timedelta(minutes=dept)
-
-        response = await self.client.get(
-            method="otp/routers/default/plan",
-            params={
-                "mode": mode,
-                "fromPlace": f"{org.lat},{org.lng}",
-                "toPlace": f"{dst.lat},{dst.lng}",
-                "time": f"{dept_datetime.time()}",
-                "date": f"{dept_datetime.date()}",
+        response = await self.client.execute_async(query, variable_values={
+            "modes": modes,
+            "date": f"{dept_datetime.date()}",
+            "time": f"{dept_datetime.time()}",
+            "from": {
+                "lat": org.lat,
+                "lon": org.lng
             },
-        )
+            "to": {
+                "lat": dst.lat,
+                "lon": dst.lng
+            }
+        })
 
-        # return shortest route
-        assert "plan" in response, f"no plan in response: {response}"
-        for itinerary in response["plan"]["itineraries"]:
-            # The OTP fixes the departure and arrival names to "Origin" and "Destination".
-            # correct them to their original names.
-            # (The named POI will have that name, so the assert statement is disabled)
-            # assert itinerary["legs"][0]["from"]["name"] == "Origin", itinerary["legs"][0]["from"]["name"]
-            # assert itinerary["legs"][-1]["to"]["name"] == "Destination", itinerary["legs"][-1]["from"]["name"]
+        for itinerary in response['plan']['itineraries']:
             itinerary["legs"][0]["from"]["name"] = org.id_
             itinerary["legs"][-1]["to"]["name"] = dst.id_
-            logger.debug(pprint.pformat(itinerary))
             yield Path(
-                trips=[self._leg_to_trip(leg) for leg in itinerary["legs"]],
-                walking_time_minutes=itinerary["walkTime"] / 60,
+                trips=[self._leg_to_trip(leg) for leg in itinerary['legs']],
+                walking_time_minutes=itinerary['walkTime'] / 60
             )
-        # else:
-        #     return []
-
-    def _get_service(self, leg: typing.Mapping):
-        mode = leg.get("mode", "").upper()
-        rented_bike = leg.get("rentedBike", False)
-        if mode == "WALK":
-            service = "walking"
-        elif rented_bike:
-            if mode not in ["BICYCLE", "CAR", "MOPED", "SCOOTER", "OTHER"]:
-                logger.warning("unknown mode with rentedBike: %s", mode)
-            networks = leg.get("from", {}).get("networks")
-            assert networks, "no networks data in leg"
-            for agency in networks:
-                if service := self.services.get(agency):
-                    break
-            else:
-                raise KeyError(
-                    f"unknown service with rentedBike: {networks} (not in {list(self.services)})"
-                )
-        else:
-            agency = get_id_from_dict(leg, "agencyId", "agencyName")
-            service = self.services.get(agency)
-            if not service:
-                raise KeyError(f"unknown agency: {agency} (not in {self.services})")
-        return service
 
     def _leg_to_trip(self, leg: typing.Mapping) -> Trip:
-        service = self._get_service(leg)
+        service = "walking" if leg['mode'] == "WALK" else self.services.get(id_from_gtfs_id(leg['agency']['gtfsId']))
+        if not service:
+            raise KeyError(f"unknown agency: {leg['agency']['gtfsId']} (not in {self.services.keys()})")
+
+        org = leg["from"]
+        dst = leg["to"]
         return Trip(
+            service=service,
             org=Location(
-                id_=get_id_from_dict(leg["from"], "stopId", "bikeShareId", "name"),
-                lat=leg["from"]["lat"],
-                lng=leg["from"]["lon"],
+                id_=id_from_gtfs_id(org['stop']['gtfsId']) if org.get('stop') else org['name'],
+                lat=org['lat'],
+                lng=org['lon'],
             ),
             dst=Location(
-                id_=get_id_from_dict(leg["to"], "stopId", "bikeShareId", "name"),
-                lat=leg["to"]["lat"],
-                lng=leg["to"]["lon"],
+                id_=id_from_gtfs_id(dst['stop']['gtfsId']) if dst.get('stop') else dst['name'],
+                lat=dst['lat'],
+                lng=dst['lon'],
             ),
-            dept=self._elapsed(leg["from"]["departure"]),
-            arrv=self._elapsed(leg["to"]["arrival"]),
-            service=service,
+            dept=self._elapsed(org['departureTime']),
+            arrv=self._elapsed(dst['arrivalTime'])
         )
+

--- a/src/planner/opentripplanner/route_planner.py
+++ b/src/planner/opentripplanner/route_planner.py
@@ -12,7 +12,6 @@ import aiohttp
 
 from core import Location, Path, Trip, calc_distance
 from jschema.response import DistanceMatrix
-from mblib.io import httputil
 
 logger = logging.getLogger(__name__)
 pattern = re.compile(r".+:(.*)")
@@ -34,18 +33,24 @@ class OpenTripPlanner:
         super().__init__()
         self.endpoint = endpoint
         self.client = Client(
-            transport=AIOHTTPTransport(url=f"{endpoint}/otp/routers/default/index/graphql"),
+            transport=AIOHTTPTransport(
+                url=f"{endpoint}/otp/routers/default/index/graphql"
+            ),
             fetch_schema_from_transport=True,
         )
         self.ref_datetime = ref_datetime
         self.walking_velocity = walking_meters_per_minute
-        self.transport_modes = transport_modes if transport_modes else [[
-            {"mode": "WALK"},
-            {"mode": "TRANSIT"},
-        ], [
-            {"mode": "WALK"},
-            {"mode": "FLEX", "qualifier": "DIRECT"}
-        ]]
+        self.transport_modes = (
+            transport_modes
+            if transport_modes
+            else [
+                [
+                    {"mode": "WALK"},
+                    {"mode": "TRANSIT"},
+                ],
+                [{"mode": "WALK"}, {"mode": "FLEX", "qualifier": "DIRECT"}],
+            ]
+        )
         self.services = services  # key: agency_id, value: service name
 
         # ToDo: overwrite otp default walking velocity to self.walking_velocity
@@ -82,7 +87,16 @@ class OpenTripPlanner:
         async with self.client as session:
             for stop_a in stops:
                 vals = await asyncio.gather(
-                    *[self.distance(session, org=stop_a, dst=stop_b, date=f"{base.date()}", time=f"{base.time()}") for stop_b in stops]
+                    *[
+                        self.distance(
+                            session,
+                            org=stop_a,
+                            dst=stop_b,
+                            date=f"{base.date()}",
+                            time=f"{base.time()}",
+                        )
+                        for stop_b in stops
+                    ]
                 )
                 matrix.append(list(vals))
         return DistanceMatrix(stops=stops_org, matrix=matrix)
@@ -90,7 +104,9 @@ class OpenTripPlanner:
     async def plan(self, org: Location, dst: Location, dept: float) -> list[Path]:
         paths: list[Path] = []
         for modes in self.transport_modes:
-            async for path in self._plan_query(modes=modes, org=org, dst=dst, dept=dept):
+            async for path in self._plan_query(
+                modes=modes, org=org, dst=dst, dept=dept
+            ):
                 if path not in paths:  # ignore duplicated walking path
                     paths.append(path)
         paths.sort(key=lambda e: e.arrv)
@@ -149,19 +165,24 @@ class OpenTripPlanner:
         }
         """)
 
-        response = await session.execute(query, variable_values={
-            "date": date,
-            "time": time,
-            "from": org,
-            "to": dst,
-        })
+        response = await session.execute(
+            query,
+            variable_values={
+                "date": date,
+                "time": time,
+                "from": org,
+                "to": dst,
+            },
+        )
 
-        if response['plan']['itineraries']:
-            return response['plan']['itineraries'][0]["walkDistance"]
+        if response["plan"]["itineraries"]:
+            return response["plan"]["itineraries"][0]["walkDistance"]
         else:
             return 0
 
-    async def _plan_query(self, modes: list[typing.Mapping], org: Location, dst: Location, dept: float):
+    async def _plan_query(
+        self, modes: list[typing.Mapping], org: Location, dst: Location, dept: float
+    ):
         query = gql("""
     query PlanQuery($modes: [TransportMode], $from: InputCoordinates, $to: InputCoordinates, $date: String, $time: String) {
       plan(
@@ -205,48 +226,54 @@ class OpenTripPlanner:
             """)
 
         dept_datetime = self.ref_datetime + datetime.timedelta(minutes=dept)
-        response = await self.client.execute_async(query, variable_values={
-            "modes": modes,
-            "date": f"{dept_datetime.date()}",
-            "time": f"{dept_datetime.time()}",
-            "from": {
-                "lat": org.lat,
-                "lon": org.lng
+        response = await self.client.execute_async(
+            query,
+            variable_values={
+                "modes": modes,
+                "date": f"{dept_datetime.date()}",
+                "time": f"{dept_datetime.time()}",
+                "from": {"lat": org.lat, "lon": org.lng},
+                "to": {"lat": dst.lat, "lon": dst.lng},
             },
-            "to": {
-                "lat": dst.lat,
-                "lon": dst.lng
-            }
-        })
+        )
 
-        for itinerary in response['plan']['itineraries']:
+        for itinerary in response["plan"]["itineraries"]:
             itinerary["legs"][0]["from"]["name"] = org.id_
             itinerary["legs"][-1]["to"]["name"] = dst.id_
             yield Path(
-                trips=[self._leg_to_trip(leg) for leg in itinerary['legs']],
-                walking_time_minutes=itinerary['walkTime'] / 60
+                trips=[self._leg_to_trip(leg) for leg in itinerary["legs"]],
+                walking_time_minutes=itinerary["walkTime"] / 60,
             )
 
     def _leg_to_trip(self, leg: typing.Mapping) -> Trip:
-        service = "walking" if leg['mode'] == "WALK" else self.services.get(id_from_gtfs_id(leg['agency']['gtfsId']))
+        service = (
+            "walking"
+            if leg["mode"] == "WALK"
+            else self.services.get(id_from_gtfs_id(leg["agency"]["gtfsId"]))
+        )
         if not service:
-            raise KeyError(f"unknown agency: {leg['agency']['gtfsId']} (not in {self.services.keys()})")
+            raise KeyError(
+                f"unknown agency: {leg['agency']['gtfsId']} (not in {self.services.keys()})"
+            )
 
         org = leg["from"]
         dst = leg["to"]
         return Trip(
             service=service,
             org=Location(
-                id_=id_from_gtfs_id(org['stop']['gtfsId']) if org.get('stop') else org['name'],
-                lat=org['lat'],
-                lng=org['lon'],
+                id_=id_from_gtfs_id(org["stop"]["gtfsId"])
+                if org.get("stop")
+                else org["name"],
+                lat=org["lat"],
+                lng=org["lon"],
             ),
             dst=Location(
-                id_=id_from_gtfs_id(dst['stop']['gtfsId']) if dst.get('stop') else dst['name'],
-                lat=dst['lat'],
-                lng=dst['lon'],
+                id_=id_from_gtfs_id(dst["stop"]["gtfsId"])
+                if dst.get("stop")
+                else dst["name"],
+                lat=dst["lat"],
+                lng=dst["lon"],
             ),
-            dept=self._elapsed(org['departureTime']),
-            arrv=self._elapsed(dst['arrivalTime'])
+            dept=self._elapsed(org["departureTime"]),
+            arrv=self._elapsed(dst["arrivalTime"]),
         )
-


### PR DESCRIPTION
The OTP REST API is scheduled for removal and is no longer recommended for use.
I have changed the internal implementation of the OTP planner from the deprecated REST API to the new GraphQL API, while keeping the external interface unchanged.

The [gql](https://pypi.org/project/gql/) library (used for GraphQL integration) is licensed under `MIT`. The previous policy only allowed libraries explicitly labeled as `MIT License` but disallowed those labeled as `MIT`. I have appended `MIT` to `allowed-lisence.lst`.
