### PR TITLE
Fix inefficiency in bus movement by restarting depart process on new reservation during wait process

### DIFF
--- a/src/base_simulators/ondemand/mobility.py
+++ b/src/base_simulators/ondemand/mobility.py
@@ -187,9 +187,9 @@ class Car(Mobility):
     def departed(self):
         self._wait_until_scheduled = self.env.process(self.wait_until_scheduled())
         cause = yield self._wait_until_scheduled
+        self._wait_until_scheduled = None
         if cause == "interrupted":
             return
-        self._wait_until_scheduled = None
 
         while users := [
             user for user in self.schedule.current.on if user in self.waiting_users

--- a/src/base_simulators/ondemand/test/test_integration.py
+++ b/src/base_simulators/ondemand/test/test_integration.py
@@ -1745,7 +1745,7 @@ class OneMobilityTestCase(unittest.TestCase):
                             }
                         ],
                     },
-                }
+                },
             ],
             triggered_events,
         )
@@ -1793,8 +1793,8 @@ class OneMobilityTestCase(unittest.TestCase):
                         "demandId": None,
                         "mobilityId": "trip",
                         "location": {"locationId": "Stop2", "lat": ..., "lng": ...},
-                    }
-                }
+                    },
+                },
             ],
             triggered_events,
         )
@@ -1811,7 +1811,7 @@ class OneMobilityTestCase(unittest.TestCase):
                         "userId": "User3",
                         "demandId": "Demand",
                         "location": {"locationId": "Stop3", "lat": ..., "lng": ...},
-                        "mobilityId": "trip"
+                        "mobilityId": "trip",
                     },
                 },
             ],
@@ -1865,8 +1865,6 @@ class OneMobilityTestCase(unittest.TestCase):
             ],
             triggered_events,
         )
-
-
 
     def test_two_reservations(self):
         run(self.simulation, until=480.0)


### PR DESCRIPTION
This pull request addresses an issue where the actual bus movement process became inefficient compared to the schedule when new reservations were made during the bus's waiting for reserved users.

When new reservations came in during the waiting state, the bus would continue to follow the old schedule, leading to inefficient movements that didn't reflect the updated schedule. By canceling the waiting process and restarting with the new schedule, the bus can move efficiently.