### PR TITLE
fixed differences in the presence of walking routes

### DIFF
--- a/src/planner/opentripplanner/route_planner.py
+++ b/src/planner/opentripplanner/route_planner.py
@@ -111,12 +111,16 @@ class OpenTripPlanner:
                     paths.append(path)
         paths.sort(key=lambda e: e.arrv)
 
-        if not paths:
-            logger.warning("no plan by OTP, and return straight walk path.")
-            return [self.straight_walk_path(org, dst, dept)]
-
-        if all(all(trip.service == "walking" for trip in path.trips) for path in paths):
-            logger.warning("no service plan by OTP, and return walk path")
+        if not any(
+            all(trip.service == "walking" for trip in path.trips) for path in paths
+        ):
+            # If a walking route is not found, append a walking route.
+            walk_path = self.straight_walk_path(org, dst, dept)
+            paths.append(walk_path)
+            if not paths:
+                logger.warning("no plan by OTP, and return straight walk path.")
+            else:
+                logger.warning("no walking plan found by OTP, and appended a walking path: %s", walk_path)
 
         return paths
 

--- a/src/planner/opentripplanner/route_planner.py
+++ b/src/planner/opentripplanner/route_planner.py
@@ -120,7 +120,10 @@ class OpenTripPlanner:
             if not paths:
                 logger.warning("no plan by OTP, and return straight walk path.")
             else:
-                logger.warning("no walking plan found by OTP, and appended a walking path: %s", walk_path)
+                logger.warning(
+                    "no walking plan found by OTP, and appended a walking path: %s",
+                    walk_path,
+                )
 
         return paths
 


### PR DESCRIPTION
This pull request addresses a regression that occurred during the GraphQL migration, affecting OTP (OpenTripPlanner) route plans when no walking route is found.
if there are not any routes with only "walking" service, a fallback straight walking route is appended to the planning paths.