### PR TITLE
Bugfix/reservation at exact time when finished waiting

### DIFF
--- a/src/base_simulators/ondemand/test/test_integration.py
+++ b/src/base_simulators/ondemand/test/test_integration.py
@@ -4,8 +4,6 @@ import unittest
 import logging
 from datetime import datetime, date, time, timedelta
 
-import simpy
-
 from simulation import Simulation, CarSetting
 from core import EventType, Stop, StopTime, Service, Trip, Group, Network
 
@@ -1608,7 +1606,8 @@ class OneMobilityTestCase(unittest.TestCase):
                             }
                         ],
                     },
-                }, {
+                },
+                {
                     "eventType": EventType.DEPARTED,
                     "time": 880.0,
                     "details": {
@@ -1617,7 +1616,7 @@ class OneMobilityTestCase(unittest.TestCase):
                         "mobilityId": "trip",
                         "location": {"locationId": "Stop2", "lat": ..., "lng": ...},
                     },
-                }
+                },
             ],
             triggered_events,
         )


### PR DESCRIPTION
This pull request addresses a critical bug in the reservation handling logic that occurs precisely at the moment when the bus’s waiting period for a reserved user ends. It ensures that the bus can handle a new reservation received at this exact timing without disrupting its scheduled operations. A corresponding test case has been added to verify the fix.

Previously, the waiting state was manually managed by tracking whether the bus was in a waiting state. This approach was prone to errors and inconsistencies. The waiting state is now automatically determined using `simpy.Process.is_alive`, which checks whether the waiting process is still running, ensuring more accurate timing and state management.