### PR TITLE
Suppress verbose logging in gql GraphQL client

### DIFF
--- a/src/planner/opentripplanner/route_planner.py
+++ b/src/planner/opentripplanner/route_planner.py
@@ -7,13 +7,14 @@ import re
 import typing
 
 from gql import Client, gql
-from gql.transport.aiohttp import AIOHTTPTransport
+from gql.transport.aiohttp import AIOHTTPTransport, log as aiohttp_logger
 import aiohttp
 
 from core import Location, Path, Trip, calc_distance
 from jschema.response import DistanceMatrix
 
 logger = logging.getLogger(__name__)
+aiohttp_logger.setLevel(logging.WARNING)
 pattern = re.compile(r".+:(.*)")
 
 


### PR DESCRIPTION
This pull request reduces the verbosity of logs generated by the gql GraphQL client library used by the OTP Planner module. By default, the library's logging is ["quite verbose" as noted in its documentation](https://gql.readthedocs.io/en/latest/advanced/logging.html#disabling-logs). This change adjusts the logging level to WARNING, ensuring only significant events are logged.