### PR TITLE
Increased timeout for calculation the matrix to 60 minutes

### DIFF
--- a/src/base_simulators/ondemand/controller.py
+++ b/src/base_simulators/ondemand/controller.py
@@ -88,7 +88,11 @@ async def setup(settings: query.Setup):
                 events.Location(locationId=e.stop_id, lat=e.lat, lng=e.lng).model_dump()
                 for e in sorted(stops.values(), key=lambda e: e.stop_id)
             ]
-            async with session.post(str(network_url), json=stops_req) as resp:
+            async with session.post(
+                str(network_url),
+                json=stops_req,
+                timeout=aiohttp.ClientTimeout(total=3600),
+            ) as resp:
                 await httputil.check_response(resp)
                 matrix = await resp.json()
             network = Network()


### PR DESCRIPTION
The timeout for calculating the matrix has been increased from the default 5 minutes to 60 minutes to handle cases where the computation takes longer.