### PR TITLE
[ondemand] allow `input_files` to accept up to 2 files (GTFS + `matrix.json`)

### DIFF
--- a/src/base_simulators/ondemand/jschema/query.py
+++ b/src/base_simulators/ondemand/jschema/query.py
@@ -25,7 +25,7 @@ class InputFilesItem(BaseModel):
 
 class Setup(BaseModel):
     reference_time: constr(min_length=8, max_length=8)
-    input_files: list[InputFilesItem] = Field(..., min_items=1, max_items=1)
+    input_files: list[InputFilesItem] = Field(..., min_items=1, max_items=2)
     network: InputFilesItem
     board_time: float | None
     max_delay_time: float | None

--- a/src/base_simulators/ondemand/requirements.txt
+++ b/src/base_simulators/ondemand/requirements.txt
@@ -4,5 +4,6 @@ pydantic_settings~=2.0.3
 python-multipart~=0.0.6
 simpy~=4.0.2
 uvicorn~=0.23.2
+attrs==24.2.0
 
 mblib @ git+https://github.com/maasblender/maasblender@68-introduce-common-library-and-common-schema#subdirectory=libs/mblib

--- a/src/base_simulators/oneway/requirements.txt
+++ b/src/base_simulators/oneway/requirements.txt
@@ -5,6 +5,7 @@ pydantic_settings~=2.0.3
 python-multipart~=0.0.6
 simpy~=4.0.2
 uvicorn~=0.23.2
+attrs==24.2.0
 
 geopy~=2.4.0
 

--- a/src/base_simulators/scheduled/requirements.txt
+++ b/src/base_simulators/scheduled/requirements.txt
@@ -4,5 +4,6 @@ pydantic_settings~=2.0.3
 python-multipart~=0.0.6
 simpy~=4.0.2
 uvicorn~=0.23.2
+attrs==24.2.0
 
 mblib @ git+https://github.com/maasblender/maasblender@68-introduce-common-library-and-common-schema#subdirectory=libs/mblib


### PR DESCRIPTION
Previously, the `input_files` field only accepted a single GTFS zip file. This update increases the `max_items` from 1 to 2 to support both a GTFS ZIP file and an additional `matrix.json` file.