### PR TITLE
optional actualDuration

### DIFF
--- a/libs/mblib/mblib/jschema/events.py
+++ b/libs/mblib/mblib/jschema/events.py
@@ -39,6 +39,7 @@ class DemandEventDetails(BaseModel, extra=Extra.allow):
     org: Location
     dst: Location
     service: str | None = None
+    actualDuration: float | None = None
     dept: float | None = None  # immediate departure demand or arrive-by demand if None
     arrv: float | None = None  # arrive-by demand if not None
 

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -311,7 +311,6 @@ async def plan(org: query.LocationSetting, dst: query.LocationSetting, dept: flo
     org = Location(id_=org.locationId, lat=org.lat, lng=org.lng)
     dst = Location(id_=dst.locationId, lat=dst.lat, lng=dst.lng)
     plans = await planner.plan(org, dst, dept)
-    print(plans)
     return plans
 
 

--- a/src/scenario/historical/core.py
+++ b/src/scenario/historical/core.py
@@ -28,6 +28,7 @@ class DemandInfo:
     service: str | None
     demand_id: str
     user_type: str | None
+    actual_duration: float | None
 
 
 @dataclass(frozen=True)
@@ -55,5 +56,6 @@ class DemandEvent:
                     "lng": info.dst.lng,
                 },
                 "service": info.service,
+                "actualDuration": info.actual_duration,
             },
         }

--- a/src/scenario/historical/historical.py
+++ b/src/scenario/historical/historical.py
@@ -67,6 +67,7 @@ class HistoricalScenario:
                     service=setting.service,
                     demand_id=setting.demand_id,
                     user_type=self._user_types[setting.user_id],
+                    actual_duration=setting.actual_duration,
                 ),
             )
             for setting in settings

--- a/src/scenario/historical/jschema/query.py
+++ b/src/scenario/historical/jschema/query.py
@@ -18,6 +18,7 @@ class HistoricalDemandSetting(BaseModel):
     user_id: str | None = None
     demand_id: str | None = None
     user_type: str | None = None
+    actual_duration: float | None = None
 
     @model_validator(mode="after")
     def check_exist_time(self):

--- a/src/scenario/historical/test/test_scenario.py
+++ b/src/scenario/historical/test/test_scenario.py
@@ -38,7 +38,22 @@ class HistoricalScenarioTestCase(unittest.TestCase):
                     dept=400.0,
                     service="mobility",
                     user_type="user-xyz",
-                )
+                ),
+                jschema.query.HistoricalDemandSetting(
+                    org=jschema.query.LocationSetting(
+                        locationId=org["locationId"],
+                        lat=org["lat"],
+                        lng=org["lng"],
+                    ),
+                    dst=jschema.query.LocationSetting(
+                        locationId=dst["locationId"], lat=dst["lat"], lng=dst["lng"]
+                    ),
+                    time=400.0,
+                    dept=400.0,
+                    service="mobility",
+                    user_type="user-xyz",
+                    actual_duration=20.0,
+                ),
             ],
             "U_%d",
             "D_%d",
@@ -56,6 +71,21 @@ class HistoricalScenarioTestCase(unittest.TestCase):
                     "org": org,
                     "dst": dst,
                     "service": "mobility",
+                    "actualDuration": None,
+                },
+            },
+            {
+                "time": 400,
+                "eventType": "DEMAND",
+                "details": {
+                    "userId": "U_2",
+                    "userType": "user-xyz",
+                    "demandId": "D_2",
+                    "dept": 400,
+                    "org": org,
+                    "dst": dst,
+                    "service": "mobility",
+                    "actualDuration": 20.0,
                 },
             },
         ]
@@ -64,7 +94,11 @@ class HistoricalScenarioTestCase(unittest.TestCase):
             {
                 "userId": "U_1",
                 "userType": "user-xyz",
-            }
+            },
+            {
+                "userId": "U_2",
+                "userType": "user-xyz",
+            },
         ]
         self.scenario.start()
         actual_events = []


### PR DESCRIPTION
This pull request adds an optional `actualDuration` field to the `scenario.historical` module. This field is not used internally during the simulation, but is intended to support post-processing and visualization of simulation results.