### PR TITLE
[evaluation] switch evaluation timing

### DIFF
--- a/ci/allowed-license.lst
+++ b/ci/allowed-license.lst
@@ -6,6 +6,7 @@ BSD License
 BSD-3-Clause
 3-Clause BSD License
 Apache-2.0
+Apache License 2.0
 Apache Software License
 Python Software Foundation License
 PSF-2.0

--- a/src/evaluation/simple/controller.py
+++ b/src/evaluation/simple/controller.py
@@ -66,6 +66,7 @@ async def setup(settings: query.Setup):
         writer,
         planner=str(settings.planner.endpoint),
         reservable=str(settings.reservable.endpoint),
+        timing=settings.evaluation_timing,
     )
     return response.Message(message="successfully configured.")
 

--- a/src/evaluation/simple/jschema/query.py
+++ b/src/evaluation/simple/jschema/query.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel, AnyHttpUrl
+from enum import Enum
+from pydantic import BaseModel, AnyHttpUrl, Field
 
 from mblib.jschema.events import DemandEvent
 
@@ -17,10 +18,16 @@ class ReservableSetting(BaseModel):
     endpoint: AnyHttpUrl
 
 
+class EvaluationTiming(str, Enum):
+    ON_DEPARTURE = 'departure'
+    ON_DEMAND = 'demand'
+
+
 class Setup(BaseModel):
     writer: ResultWriterSetting = ResultWriterSetting()
     planner: PlannerSetting
     reservable: ReservableSetting
+    evaluation_timing: EvaluationTiming = Field(default=EvaluationTiming.ON_DEPARTURE)
 
 
 TriggeredEvent = DemandEvent

--- a/src/evaluation/simple/jschema/query.py
+++ b/src/evaluation/simple/jschema/query.py
@@ -19,8 +19,8 @@ class ReservableSetting(BaseModel):
 
 
 class EvaluationTiming(str, Enum):
-    ON_DEPARTURE = 'departure'
-    ON_DEMAND = 'demand'
+    ON_DEPARTURE = "departure"
+    ON_DEMAND = "demand"
 
 
 class Setup(BaseModel):

--- a/src/evaluation/simple/test/test_usability.py
+++ b/src/evaluation/simple/test/test_usability.py
@@ -5,6 +5,7 @@ import pathlib
 import unittest
 import unittest.mock
 
+from jschema.query import EvaluationTiming
 from mblib.io.result import FileResultWriter
 from core import Location
 from planner import Route, Trip
@@ -36,6 +37,7 @@ class EvaluationTestCase(unittest.IsolatedAsyncioTestCase):
             FileResultWriter(TEST_FILE),
             "",
             "",
+            timing=EvaluationTiming.ON_DEPARTURE,
         )
         self.user_id = "U_001"
         plan = unittest.mock.AsyncMock()

--- a/src/evaluation/simple/usability.py
+++ b/src/evaluation/simple/usability.py
@@ -26,7 +26,13 @@ class UsabilityEvaluator:
     reserver: ReservableChecker
     timing: EvaluationTiming
 
-    def __init__(self, logger: ResultWriter, planner: str, reservable: str, timing: EvaluationTiming):
+    def __init__(
+        self,
+        logger: ResultWriter,
+        planner: str,
+        reservable: str,
+        timing: EvaluationTiming,
+    ):
         self.logger = logger
         self.planner = Planner(planner)
         self.reserver = ReservableChecker(reservable)

--- a/src/evaluation/simple/usability.py
+++ b/src/evaluation/simple/usability.py
@@ -8,7 +8,7 @@ from simpy import Environment
 from mblib.io.result import ResultWriter
 from planner import Location, Route, Planner, ReservableChecker
 from event import EventQueue, DemandEvent
-from src.evaluation.simple.jschema.query import EvaluationTiming
+from jschema.query import EvaluationTiming
 
 
 def near_locations(loc1: Location, loc2: Location, *, delta: float):

--- a/src/evaluation/simple/usability.py
+++ b/src/evaluation/simple/usability.py
@@ -8,6 +8,7 @@ from simpy import Environment
 from mblib.io.result import ResultWriter
 from planner import Location, Route, Planner, ReservableChecker
 from event import EventQueue, DemandEvent
+from src.evaluation.simple.jschema.query import EvaluationTiming
 
 
 def near_locations(loc1: Location, loc2: Location, *, delta: float):
@@ -21,13 +22,15 @@ def near_locations(loc1: Location, loc2: Location, *, delta: float):
 
 class UsabilityEvaluator:
     logger: ResultWriter
-    planner: Planner | None
-    reserver: ReservableChecker | None
+    planner: Planner
+    reserver: ReservableChecker
+    timing: EvaluationTiming
 
-    def __init__(self, logger: ResultWriter, planner: str, reservable: str):
+    def __init__(self, logger: ResultWriter, planner: str, reservable: str, timing: EvaluationTiming):
         self.logger = logger
         self.planner = Planner(planner)
         self.reserver = ReservableChecker(reservable)
+        self.timing = timing
         self.env = Environment()
         self.event_queue = EventQueue(self.env)
 
@@ -61,7 +64,11 @@ class UsabilityEvaluator:
         self.env.process(self._demand(demand))
 
     def _demand(self, demand: DemandEvent):
-        yield self.env.timeout(demand.dept - self.env.now)
+        match self.timing:
+            case EvaluationTiming.ON_DEPARTURE:
+                yield self.env.timeout(demand.dept - self.env.now)
+            case EvaluationTiming.ON_DEMAND:
+                yield self.env.timeout(0)
         self.event_queue.demand(demand)
 
     async def step(self):


### PR DESCRIPTION
This pull request introduces the following changes:

- Adds an `EvaluationTiming` to explicitly represent when evaluations are performed (on `departure` or on `demand`).
- Sets the default timing to `ON_DEPARTURE`. (current behavior)
