### PR TITLE
Time limit of 120 seconds for a search.

### DIFF
--- a/src/base_simulators/ondemand/mobility.py
+++ b/src/base_simulators/ondemand/mobility.py
@@ -401,6 +401,9 @@ class Car(Mobility):
             routing_enums_pb2.FirstSolutionStrategy.PARALLEL_CHEAPEST_INSERTION
         )
 
+        # Add time limit
+        search_parameters.time_limit.FromSeconds(10)
+
         # Solve the problem.
         solution = routing.SolveWithParameters(search_parameters)
 


### PR DESCRIPTION
To prevent excessive computation time, a 120-second search limit has been added.
This ensures the solver will terminate gracefully and return the best solution found within the time limit.
cf.) https://developers.google.com/optimization/routing/routing_tasks