### PR TITLE
OTP2.6におけるGTFS Flex対応

### DIFF
--- a/src/base_simulators/ondemand/gtfs.py
+++ b/src/base_simulators/ondemand/gtfs.py
@@ -107,8 +107,8 @@ class GtfsFlexFilesReader:
             {
                 row["trip_id"]: StopTime(
                     group=self.location_groups[location_group_id],
-                    start_window=str_time(row["start_pickup_dropoff_window"]),
-                    end_window=str_time(row["end_pickup_dropoff_window"]),
+                    start_window=str_time(row["start_pickup_drop_off_window"]),
+                    end_window=str_time(row["end_pickup_drop_off_window"]),
                 )
             }
         )

--- a/src/planner/opentripplanner/route_planner.py
+++ b/src/planner/opentripplanner/route_planner.py
@@ -190,7 +190,9 @@ class OpenTripPlanner:
             maxTransfers: 1
           ) {
             itineraries {
-              walkDistance 
+                legs {
+                    distance
+                }
             }
           }
         }
@@ -207,7 +209,12 @@ class OpenTripPlanner:
         )
 
         if response["plan"]["itineraries"]:
-            return response["plan"]["itineraries"][0]["walkDistance"]
+            # すべての legs の distance を合計
+            total_distance = sum(
+                leg.get("distance", 0)
+                for leg in response["plan"]["itineraries"][0]["legs"]
+            )
+            return total_distance
         else:
             return 0
 
@@ -309,6 +316,11 @@ class OpenTripPlanner:
             service = self.services[org["vehicleRentalStation"]["network"]]
             org_id = id_from_gtfs_id(org["vehicleRentalStation"]["stationId"])
             dst_id = id_from_gtfs_id(dst["vehicleRentalStation"]["stationId"])
+        elif leg["mode"] == "FLEX":
+            # Flex
+            service = "ondemand"
+            org_id = org["name"]
+            dst_id = dst["name"]
         # GTFS
         else:
             service = self.services[id_from_gtfs_id(leg["agency"]["gtfsId"])]

--- a/src/planner/simple/gtfs_flex/reader.py
+++ b/src/planner/simple/gtfs_flex/reader.py
@@ -36,6 +36,7 @@ class FilesReader:
         for filename, parse in {
             "stops.txt": self._parse_stop,
             "location_groups.txt": self._parse_location_groups,
+            "location_group_stops.txt": self._parse_location_group_stops,
             "calendar.txt": self._parse_calender,
             "calendar_dates.txt": self._parse_calender_dates,
             "stop_times.txt": self._parse_stop_time,
@@ -63,8 +64,14 @@ class FilesReader:
         if not group:
             group = Group(group_id=group_id, name=row["location_group_name"])
             self.location_groups[group_id] = group
-        group.locations.append(self.stops[row["location_id"]])
+        # in new GTFS FLEX spec., separated this 'location_id' column into location_group_stops.txt
+        if location_id := row.get("location_id", None):
+            group.locations.append(self.stops[location_id])
 
+    def _parse_location_group_stops(self, row: typing.Mapping[str, str]):
+        group_id = row["location_group_id"]
+        self.location_groups[group_id].locations.append(self.stops[row["stop_id"]])
+        
     def _parse_calender(self, row: typing.Mapping[str, str]):
         self._services.update(
             {
@@ -92,8 +99,8 @@ class FilesReader:
             {
                 row["trip_id"]: StopTime(
                     group=self.location_groups[row["stop_id"]],
-                    start_window=str_time(row["start_pickup_dropoff_window"]),
-                    end_window=str_time(row["end_pickup_dropoff_window"]),
+                    start_window=str_time(row["start_pickup_drop_off_window"]),
+                    end_window=str_time(row["end_pickup_drop_off_window"]),
                 )
             }
         )


### PR DESCRIPTION
@yukifuji さん、@piriwataさん 
お手すきの際に以下PRレビューをお願いします。

### 概要

OTP2.6以降で採用された正式版GTFS Flexに対応しました。

シミュレーションロジックには変更を加えず、GTFSの読み込み(I/O層)およびOTPとの連携部分のみを修正しています。

### 修正内容

- OTPから取得する徒歩距離を`walkDistance`ではなく`legs[].distance`の合計から取得
- GTFS Flex正式版のカラム名変更に対応
  - `start_pickup_dropoff_window`
    → `start_pickup_drop_off_window`
  - `end_pickup_dropoff_window`
    → `end_pickup_drop_off_window`