### PR TITLE
Migration to Ruff v0.16

### DIFF
--- a/.github/workflows/lint_and_format.yaml
+++ b/.github/workflows/lint_and_format.yaml
@@ -7,7 +7,7 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
-  check-license:
+  lint-and-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/ci/arriveby-ondemand-scheduled-case/run_integration_test.py
+++ b/ci/arriveby-ondemand-scheduled-case/run_integration_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Integration test for arrive-by scenario with historical, generator, and commuter.
 
@@ -14,7 +13,7 @@ import random
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any, Optional, List
+from typing import Any
 
 import httpx
 
@@ -55,7 +54,7 @@ def request_with_retry(
     method: str,
     url: str,
     *,
-    timeout: Optional[httpx.Timeout] = None,
+    timeout: httpx.Timeout | None = None,
     attempts: int = RETRY_ATTEMPTS,
     **kwargs,
 ) -> httpx.Response:
@@ -144,7 +143,7 @@ def assert_message(data: dict[str, Any], expected_message: str) -> None:
 def post(
     client: httpx.Client,
     url: str,
-    params: Optional[dict] = None,
+    params: dict | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     return request_with_retry(client, "POST", url, params=params, **kwargs).json()
@@ -207,7 +206,7 @@ def get_user_ids(events: list[dict[str, Any]], prefix: str) -> list[str]:
     )
 
 
-def assert_arrived_by(trips: List[Trip], arrived: str, by: float) -> None:
+def assert_arrived_by(trips: list[Trip], arrived: str, by: float) -> None:
     if not trips:
         print(f"  [FAIL] no trips found. expected arrival at {arrived} by {by}")
         sys.exit(1)
@@ -224,7 +223,7 @@ def assert_arrived_by(trips: List[Trip], arrived: str, by: float) -> None:
     sys.exit(1)
 
 
-def assert_used_service(trips: List[Trip], service: str) -> None:
+def assert_used_service(trips: list[Trip], service: str) -> None:
     if any(trip.service == service for trip in trips):
         print(f"  [OK] service used: {service}")
         return
@@ -273,8 +272,8 @@ def assert_any_generator_user_arrived(
 
 
 def split_commuter_trips(
-    trips: List[Trip], turnaround_dst: str
-) -> tuple[List[Trip], List[Trip]]:
+    trips: list[Trip], turnaround_dst: str
+) -> tuple[list[Trip], list[Trip]]:
     """Split commuter trips into outbound and inbound segments.
 
     Outbound is from the first trip up to the first arrival at ``turnaround_dst``.

--- a/ci/ondemand-oneway-generator-commuter-case/run_integration_test.py
+++ b/ci/ondemand-oneway-generator-commuter-case/run_integration_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Integration test for the ondemand + oneway + generator + commuter scenario.
 
@@ -15,7 +14,7 @@ import random
 import sys
 import time
 from dataclasses import dataclass
-from typing import Any, Optional, List
+from typing import Any
 
 import httpx
 
@@ -39,7 +38,7 @@ def request_with_retry(
     method: str,
     url: str,
     *,
-    timeout: Optional[httpx.Timeout] = None,
+    timeout: httpx.Timeout | None = None,
     attempts: int = RETRY_ATTEMPTS,
     **kwargs,
 ) -> httpx.Response:
@@ -128,7 +127,7 @@ def assert_message(data: dict[str, Any], expected_message: str) -> None:
 def post(
     client: httpx.Client,
     url: str,
-    params: Optional[dict] = None,
+    params: dict | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     return request_with_retry(client, "POST", url, params=params, **kwargs).json()
@@ -196,7 +195,7 @@ def get_user_trips(events: list[dict[str, Any]], user_id: str) -> list[Trip]:
 
 
 def assert_departed_at(
-    trips: List[Trip], departed_from: str, at: float, tolerance: float = 1e-6
+    trips: list[Trip], departed_from: str, at: float, tolerance: float = 1e-6
 ) -> None:
     if not trips:
         print(
@@ -216,7 +215,7 @@ def assert_departed_at(
     sys.exit(1)
 
 
-def assert_arrived_at(trips: List[Trip], arrived: str) -> None:
+def assert_arrived_at(trips: list[Trip], arrived: str) -> None:
     if not trips:
         print(f"  [FAIL] no trips found. expected arrival at {arrived}")
         sys.exit(1)
@@ -233,7 +232,7 @@ def assert_arrived_at(trips: List[Trip], arrived: str) -> None:
     sys.exit(1)
 
 
-def assert_used_service(trips: List[Trip], service: str) -> None:
+def assert_used_service(trips: list[Trip], service: str) -> None:
     if any(trip.service == service for trip in trips):
         print(f"  [OK] service used: {service}")
         return
@@ -243,8 +242,8 @@ def assert_used_service(trips: List[Trip], service: str) -> None:
 
 
 def split_first_commuter_round_trip(
-    trips: List[Trip], turnaround_dst: str, return_dst: str
-) -> tuple[List[Trip], List[Trip]]:
+    trips: list[Trip], turnaround_dst: str, return_dst: str
+) -> tuple[list[Trip], list[Trip]]:
     if not trips:
         print("  [FAIL] commuter trips are empty")
         sys.exit(1)

--- a/ci/scheduled-routedeviation-historical/run_integration_test.py
+++ b/ci/scheduled-routedeviation-historical/run_integration_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """
 Integration test for the scheduled + route-deviation + historical scenario.
 
@@ -16,7 +15,7 @@ import shutil
 import sys
 import time
 from dataclasses import dataclass
-from typing import Optional, Any, List
+from typing import Any
 
 import httpx
 
@@ -40,7 +39,7 @@ def request_with_retry(
     method: str,
     url: str,
     *,
-    timeout: Optional[httpx.Timeout] = None,
+    timeout: httpx.Timeout | None = None,
     attempts: int = RETRY_ATTEMPTS,
     **kwargs,
 ) -> httpx.Response:
@@ -129,7 +128,7 @@ def assert_message(data: dict[str, Any], expected_message: str) -> None:
 def post(
     client: httpx.Client,
     url: str,
-    params: Optional[dict] = None,
+    params: dict | None = None,
     **kwargs,
 ) -> dict[str, Any]:
     return request_with_retry(client, "POST", url, params=params, **kwargs).json()
@@ -197,7 +196,7 @@ def get_user_trips(events: list[dict[str, Any]], user_id: str) -> list[Trip]:
 
 
 def assert_departed_at(
-    trips: List[Trip], departed_from: str, at: float, tolerance: float = 1e-6
+    trips: list[Trip], departed_from: str, at: float, tolerance: float = 1e-6
 ) -> None:
     if not trips:
         print(
@@ -217,7 +216,7 @@ def assert_departed_at(
     sys.exit(1)
 
 
-def assert_arrived_at(trips: List[Trip], arrived: str) -> None:
+def assert_arrived_at(trips: list[Trip], arrived: str) -> None:
     if not trips:
         print(f"  [FAIL] no trips found. expected arrival at {arrived}")
         sys.exit(1)
@@ -234,7 +233,7 @@ def assert_arrived_at(trips: List[Trip], arrived: str) -> None:
     sys.exit(1)
 
 
-def assert_used_service(trips: List[Trip], service: str) -> None:
+def assert_used_service(trips: list[Trip], service: str) -> None:
     if any(trip.service == service for trip in trips):
         print(f"  [OK] service used: {service}")
         return

--- a/examples/quick-start/execute_simulation.py
+++ b/examples/quick-start/execute_simulation.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import time
 from pathlib import Path
 
@@ -24,7 +25,7 @@ def main():
                 },
                 headers={"accept": "application/json"},
             )
-            if not response.status_code == 200:
+            if response.status_code != 200:
                 print(response.text)
                 return
             print(response.json())
@@ -41,7 +42,7 @@ def main():
                 },
                 headers={"accept": "application/json"},
             )
-            if not response.status_code == 200:
+            if response.status_code != 200:
                 print(response.text)
                 return
             print(response.json())
@@ -59,7 +60,7 @@ def main():
                 },
                 headers={"accept": "application/json"},
             )
-            if not response.status_code == 200:
+            if response.status_code != 200:
                 print(response.text)
                 return
             print(response.json())
@@ -79,9 +80,9 @@ def main():
             print(response.json())
             if response.status_code != 200:
                 return
-        except Exception:
+        except json.JSONDecodeError:
             print(response.text)
-            exit(-1)
+            sys.exit(-1)
 
         # 4. Starts the broker service
         # Sends a request to `localhost:3000/start` to start the initialization process.
@@ -90,9 +91,9 @@ def main():
         )
         try:
             print(response.json())
-        except Exception:
+        except json.JSONDecodeError:
             print(response.text)
-            exit(-1)
+            sys.exit(-1)
 
         # 5. Runs the simulation
         # Sends a request to `localhost:3000/run` with a simulation duration parameter (`until=1440`).
@@ -103,9 +104,9 @@ def main():
         )
         try:
             print(response.json())
-        except Exception:
+        except json.JSONDecodeError:
             print(response.text)
-            exit(-2)
+            sys.exit(-2)
 
         # 6. Periodically checks the simulation status
         # Polls the broker service every 10 seconds to check if the simulation is still running.
@@ -123,8 +124,8 @@ def main():
                     print("running:", next_time)
                 else:
                     print("failed", next_time)
-                    exit(-3)
-            except Exception:
+                    sys.exit(-3)
+            except json.JSONDecodeError:
                 print(response.text)
         print("successfully finished.")
 

--- a/libs/mblib/mblib/io/httputil.py
+++ b/libs/mblib/mblib/io/httputil.py
@@ -100,7 +100,7 @@ class FileManager:
         session: aiohttp.ClientSession,
         *,
         url: str | pydantic.AnyHttpUrl = None,
-        filename: str = None,
+        filename: str | None = None,
     ) -> tuple[str, bytes]:
         if url:
             if not isinstance(url, str):

--- a/libs/mblib/mblib/io/log.py
+++ b/libs/mblib/mblib/io/log.py
@@ -17,12 +17,12 @@ logger = logging.getLogger(__name__)
 
 
 class AsyncHttpSeqnoHandler(logging.Handler):
-    _instances: list[AsyncHttpSeqnoHandler] = []
+    _instances: typing.ClassVar[list[AsyncHttpSeqnoHandler]] = []
     _url: str
     _session: aiohttp.ClientSession
     _count: itertools.count
     _records: asyncio.Queue[logging.LogRecord]
-    _task: typing.Optional[asyncio.Task]
+    _task: asyncio.Task | None
     _closed: bool
 
     @classmethod
@@ -85,7 +85,7 @@ class AsyncHttpSeqnoHandler(logging.Handler):
 
     async def _send_records(self, nowait=False):
         data = [
-            dict(seqno=next(self._count), data=json.loads(record.getMessage()))
+            {"seqno": next(self._count), "data": json.loads(record.getMessage())}
             async for record in self._pop_records(nowait)
         ]
         if data:

--- a/libs/mblib/mblib/io/result.py
+++ b/libs/mblib/mblib/io/result.py
@@ -99,7 +99,7 @@ class HTTPResultWriter:
 
     async def _send_records(self, nowait=False):
         data = [
-            dict(seqno=next(self._count), data=record)
+            {"seqno": next(self._count), "data": record}
             async for record in self._pop_records(nowait)
         ]
         if data:

--- a/libs/mblib/mblib/jschema/response.py
+++ b/libs/mblib/mblib/jschema/response.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import typing
 
-from pydantic import BaseModel
-
 from mblib.jschema.events import Event
+from pydantic import BaseModel
 
 
 class Message(BaseModel):

--- a/libs/mblib/mblib/jschema/spec.py
+++ b/libs/mblib/mblib/jschema/spec.py
@@ -4,7 +4,7 @@ import dataclasses
 import typing
 from functools import cached_property
 
-from pydantic import BaseModel, Field, AnyHttpUrl
+from pydantic import AnyHttpUrl, BaseModel, Field
 from pydantic.json_schema import JsonSchemaValue
 
 TxRx = typing.Literal["Tx", "Rx"]
@@ -32,7 +32,7 @@ class EventDefinition(BaseModel):
     )
 
     @staticmethod
-    def inspect(dir_: TxRx, event_class: typing.Type[BaseModel]):
+    def inspect(dir_: TxRx, event_class: type[BaseModel]):
         if hasattr(event_class, "feature"):
             feature = event_class.feature
         else:
@@ -55,9 +55,7 @@ class SpecificationResponse(BaseModel):
 
 
 # class type of StepEvent or TriggeredEvent
-EventClassType = (
-    typing.Union[typing.Type[BaseModel], ...] | typing.Type[BaseModel] | None
-)
+EventClassType = typing.Any
 
 
 @dataclasses.dataclass(frozen=True)
@@ -66,9 +64,7 @@ class EventSpecificationBuilder:
     step: dataclasses.InitVar[EventClassType | None] = None
     triggered: dataclasses.InitVar[EventClassType | None] = None
 
-    def __post_init__(
-        self, step: EventClassType = None, triggered: EventClassType = None
-    ):
+    def __post_init__(self, step: EventClassType, triggered: EventClassType):
         # set event specification of step API response
         self._set_events("Tx", step)
         # set event specification of triggered API request
@@ -93,8 +89,8 @@ class EventSpecificationBuilder:
         self,
         event_type: typing.Any,
         *,
-        declared: list[str] = None,
-        required: list[str] = None,
+        declared: list[str] | None = None,
+        required: list[str] | None = None,
     ) -> None:
         """set feature definition for step or triggered event specification"""
         feature = FeatureDefinition(declared=declared, required=required)

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+ignore = ["DTZ007"]

--- a/src/base_simulators/ondemand/controller.py
+++ b/src/base_simulators/ondemand/controller.py
@@ -1,21 +1,21 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
-import json
 import io
+import json
 import logging
 import zipfile
+from typing import Annotated
 
 import aiohttp
 import fastapi
-
 from core import Network
 from gtfs import GtfsFlexFilesReader
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
-from mblib.jschema import spec, events
-from simulation import Simulation, CarSetting
+from mblib.jschema import events, spec
+from simulation import CarSetting, Simulation
 
 logger = logging.getLogger(__name__)
 app = fastapi.FastAPI(
@@ -63,7 +63,7 @@ def get_specification():
 
 
 @app.post("/upload", response_model=response.Message)
-def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
+def upload(upload_file: Annotated[fastapi.UploadFile, fastapi.File(...)]):
     try:
         file_table.put(upload_file)
     finally:
@@ -75,7 +75,7 @@ def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
 async def setup(settings: query.Setup):
     async with aiohttp.ClientSession() as session:
         ref = settings.input_files[0]
-        filename, data = await file_table.pop(
+        _filename, data = await file_table.pop(
             session, filename=ref.filename, url=ref.fetch_url
         )
         with zipfile.ZipFile(io.BytesIO(data)) as archive:
@@ -127,7 +127,9 @@ async def setup(settings: query.Setup):
 
     global sim
     sim = Simulation(
-        start_time=datetime.datetime.strptime(settings.reference_time, "%Y%m%d"),
+        start_time=datetime.datetime.strptime(
+            settings.reference_time, "%Y%m%d"
+        ).replace(tzinfo=datetime.timezone.utc),
         network=network,
         trips=trips,
         enable_ortools=settings.enable_ortools,

--- a/src/base_simulators/ondemand/core.py
+++ b/src/base_simulators/ondemand/core.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
 import typing
-from enum import Enum
 from datetime import date, datetime, timedelta
+from enum import Enum
 
 
 class EventType(str, Enum):
@@ -51,8 +51,8 @@ class Service:
         self._start_day = start_date
         self._end_day = end_date
         self._weekday = [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
-        self._added_exceptions: typing.List[date] = []
-        self._removed_exceptions: typing.List[date] = []
+        self._added_exceptions: list[date] = []
+        self._removed_exceptions: list[date] = []
 
     def __repr__(self):
         weekday = "".join(str(int(e)) for e in self._weekday)

--- a/src/base_simulators/ondemand/event.py
+++ b/src/base_simulators/ondemand/event.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import datetime
-import typing
 
 from core import EventType, Mobility, User
 from environment import Environment
@@ -12,7 +11,7 @@ class TriggerEvent:
         self.event_type = event_type
         self.env = env
 
-    def dumps(self) -> typing.Dict:
+    def dumps(self) -> dict:
         return {"eventType": self.event_type, "time": self.env.now}
 
 
@@ -114,7 +113,7 @@ class ArrivedEvent(DepartedArrivedEvent):
 class EventQueue:
     def __init__(self, env: Environment):
         self._env = env
-        self._events: typing.List[typing.Dict] = []
+        self._events: list[dict] = []
 
     def __repr__(self):
         return f"EventQueue(env=Environment({self.env.datetime_now}), events={self._events})"

--- a/src/base_simulators/ondemand/gtfs.py
+++ b/src/base_simulators/ondemand/gtfs.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import typing
-import datetime
 import csv
+import datetime
 import io
-import zipfile
 import re
+import typing
+import zipfile
 
-from core import Stop, Group, StopTime, Service, Trip
-
+from core import Group, Service, Stop, StopTime, Trip
 
 p = re.compile(r"(\d\d?):(\d\d?):(\d\d?)")
 
@@ -23,16 +22,16 @@ def str_time(time: str):
 
 
 def str_date(time: str):
-    return datetime.datetime.strptime(time, "%Y%m%d").date()
+    return datetime.date.fromisoformat(f"{time[:4]}-{time[4:6]}-{time[6:8]}")
 
 
 class GtfsFlexFilesReader:
     def __init__(self):
-        self.stops: typing.Dict[str, Stop] = {}
-        self.location_groups: typing.Dict[str, Group] = {}
-        self._stop_times: typing.Dict[str, StopTime] = {}
-        self._services: typing.Dict[str, Service] = {}
-        self.trips: typing.Dict[str, Trip] = {}
+        self.stops: dict[str, Stop] = {}
+        self.location_groups: dict[str, Group] = {}
+        self._stop_times: dict[str, StopTime] = {}
+        self._services: dict[str, Service] = {}
+        self.trips: dict[str, Trip] = {}
 
     def read(self, archive: zipfile.ZipFile):
         for filename, parse in {

--- a/src/base_simulators/ondemand/jschema/query.py
+++ b/src/base_simulators/ondemand/jschema/query.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel, Field, AnyHttpUrl, model_validator, constr
-
-from mblib.jschema.events import ReserveEvent, DepartEvent
+from mblib.jschema.events import DepartEvent, ReserveEvent
+from pydantic import AnyHttpUrl, BaseModel, Field, constr, model_validator
 
 
 class Mobility(BaseModel):

--- a/src/base_simulators/ondemand/jschema/response.py
+++ b/src/base_simulators/ondemand/jschema/response.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel
 import typing
 
 from mblib.jschema import response
-from mblib.jschema.events import ReservedEvent, DepartedEvent, ArrivedEvent
-
+from mblib.jschema.events import ArrivedEvent, DepartedEvent, ReservedEvent
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/base_simulators/ondemand/mobility.py
+++ b/src/base_simulators/ondemand/mobility.py
@@ -3,26 +3,24 @@
 from __future__ import annotations
 
 import dataclasses
+import functools
+import itertools
 import logging
 import time
 import typing
 from datetime import datetime, timedelta
-import itertools
-import functools
 
 import simpy
-from ortools.constraint_solver import routing_enums_pb2
-from ortools.constraint_solver import pywrapcp
-
-from core import Trip, Stop, Network, User, Mobility
+from core import Mobility, Network, Stop, Trip, User
 from event import EventQueue
+from ortools.constraint_solver import pywrapcp, routing_enums_pb2
 
 logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
 class Schedule:
-    current: typing.Optional[StopTime] = None
+    current: StopTime | None = None
     stop_times: typing.Sequence[StopTime] = dataclasses.field(default_factory=list)
 
     def __bool__(self):
@@ -45,7 +43,7 @@ class Schedule:
             self.stop_times = self.stop_times[1:]
         else:
             self.current = None
-            self.stop_times: typing.List[StopTime] = []
+            self.stop_times: list[StopTime] = []
         return self.current
 
 
@@ -61,8 +59,8 @@ class TimeoutWatchDog:
 
 @dataclasses.dataclass
 class OnOff:
-    on: typing.Optional[User] = None
-    off: typing.Optional[User] = None
+    on: User | None = None
+    off: User | None = None
 
 
 class Car(Mobility):
@@ -89,13 +87,13 @@ class Car(Mobility):
         self.schedule = Schedule()
         self._last_arrival_time = self.env.datetime_now
         self._initial_stop = stop
-        self._stop: typing.Optional[Stop] = stop
+        self._stop: Stop | None = stop
         self._board_time: timedelta = board_time
         self._max_delay_time: timedelta = max_delay_time
-        self._reserved_users: typing.Dict[str, User] = {}
-        self._waiting_users: typing.Dict[str, User] = {}
-        self._passengers: typing.Dict[str, User] = {}
-        self._wait_until_scheduled: typing.Optional[simpy.Process] = None
+        self._reserved_users: dict[str, User] = {}
+        self._waiting_users: dict[str, User] = {}
+        self._passengers: dict[str, User] = {}
+        self._wait_until_scheduled: simpy.Process | None = None
         _, end_window = self.window()
         self.env.process(
             self._move_to_initial_stop(end_window)
@@ -212,7 +210,7 @@ class Car(Mobility):
                 f"illegal current schedule of mobility={self.mobility_id}"
                 f" with users={[e.user_id for e in users]} at {self.env.now=}:"
                 f" {self.schedule.current.stop=} != {self.stop=}"
-                f"\n  car={repr(self)}"
+                f"\n  car={self!r}"
             )
             for user in users:
                 assert user.org == self.stop
@@ -225,7 +223,7 @@ class Car(Mobility):
                 f"capacity over of mobility={self.mobility_id} on stop={self.stop}"
                 f" with users={[e.user_id for e in users]} at {self.env.now=}:"
                 f" len({[e.user_id for e in self.passengers]=}) > {self.capacity=}"
-                f"\n  car={repr(self)}"
+                f"\n  car={self!r}"
             )
 
         self.env.process(self.move(self.schedule.pop().stop))
@@ -259,7 +257,7 @@ class Car(Mobility):
 
         self.env.process(self.arrived())
 
-    def solve_new_route(self, new_user: User) -> typing.Optional[Route]:
+    def solve_new_route(self, new_user: User) -> Route | None:
         node_locations = []
         demands = []
         node_onoff = []
@@ -321,7 +319,7 @@ class Car(Mobility):
             start_time = to.arrival
         else:
             now = self.env.datetime_now
-            start_time = now if now > window_start else window_start
+            start_time = max(window_start, now)
         time_dimension.CumulVar(routing.Start(0)).SetValue(
             self.env.elapsed_secs(start_time)
         )
@@ -491,7 +489,7 @@ class Car(Mobility):
 
         return routes
 
-    def reserve(self, user: User, schedule: typing.List[StopTime]):
+    def reserve(self, user: User, schedule: list[StopTime]):
         # Ensure that the user has not already reserved
         assert user.user_id not in self.users
 
@@ -511,9 +509,9 @@ class Car(Mobility):
         self.schedule.update(schedule)
         self._reserved_users.update({user.user_id: user})
 
-    def window(self) -> typing.Tuple[datetime | None, datetime | None]:
+    def window(self) -> tuple[datetime | None, datetime | None]:
         now = self.env.datetime_now
-        today = datetime(year=now.year, month=now.month, day=now.day)
+        today = now.replace(hour=0, minute=0, second=0, microsecond=0)
         if trip := self.trip(today.date() - timedelta(days=1)):
             # yesterday's after midnight
             start_window = today
@@ -534,8 +532,8 @@ class Car(Mobility):
 
 
 class Route:
-    def __init__(self, stop_times: typing.List[StopTime]):
-        def _normalize(a: typing.List[StopTime], b: StopTime):
+    def __init__(self, stop_times: list[StopTime]):
+        def _normalize(a: list[StopTime], b: StopTime):
             return a[:-1] + [a[-1] + b] if a and a[-1].stop == b.stop else a + [b]
 
         self.stop_times = functools.reduce(_normalize, stop_times, [])
@@ -570,8 +568,8 @@ class StopTime:
     stop: Stop
     arrival: datetime = None
     departure: datetime = None
-    on: typing.List[User] = dataclasses.field(default_factory=list)
-    off: typing.List[User] = dataclasses.field(default_factory=list)
+    on: list[User] = dataclasses.field(default_factory=list)
+    off: list[User] = dataclasses.field(default_factory=list)
 
     def __eq__(self, other):
         if not isinstance(other, StopTime):
@@ -617,10 +615,12 @@ class Evaluation:
                 # wait till start time
                 previous = StopTime(stop=car.stop, departure=start_window)
 
-        for previous, stop_time in zip([previous] + plan.stop_times, plan.stop_times):
-            stop_time.arrival = previous.departure + timedelta(
+        for previous_stop_time, stop_time in zip(
+            [previous] + plan.stop_times, plan.stop_times
+        ):
+            stop_time.arrival = previous_stop_time.departure + timedelta(
                 minutes=self.car.network.duration(
-                    previous.stop.stop_id, stop_time.stop.stop_id
+                    previous_stop_time.stop.stop_id, stop_time.stop.stop_id
                 )
             )
             stop_time.departure = max(
@@ -675,7 +675,7 @@ class CarManager:
         self.max_delay_time: timedelta = timedelta(minutes=max_delay_time)
         self.max_calculation_seconds = max_calculation_seconds
         self.max_calculation_stop_times_length = max_calculation_stop_times_length
-        self.mobilities: typing.Dict[str, Car] = {
+        self.mobilities: dict[str, Car] = {
             setting.mobility_id: Car(
                 network=self.network,
                 queue=self.event_queue,

--- a/src/base_simulators/ondemand/simulation.py
+++ b/src/base_simulators/ondemand/simulation.py
@@ -4,8 +4,8 @@ import typing
 from datetime import datetime, timedelta
 from logging import getLogger
 
+from core import Network, Trip, User
 from environment import Environment
-from core import Network, User, Trip
 from event import EventQueue
 from mobility import CarManager, CarSetting
 
@@ -58,7 +58,7 @@ class Simulation:
         self.env.step()
         return self.env.now
 
-    def reservable(self, org: str, dst: str, dept: float = None):
+    def reservable(self, org: str, dst: str, dept: float | None = None):
         org = self.stops[org]
         dst = self.stops[dst]
         return bool(

--- a/src/base_simulators/ondemand/test/test_gtfs.py
+++ b/src/base_simulators/ondemand/test/test_gtfs.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import datetime
+import unittest
 
-from core import Stop, Group, StopTime, Service, Trip
+from core import Group, Service, Stop, StopTime, Trip
 from gtfs import GtfsFlexFilesReader
 
 

--- a/src/base_simulators/ondemand/test/test_integration.py
+++ b/src/base_simulators/ondemand/test/test_integration.py
@@ -1,13 +1,14 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import logging
-from datetime import datetime, date, time, timedelta
+import unittest
+from datetime import date, datetime, time, timedelta
 
-from simulation import Simulation, CarSetting
-from core import EventType, Stop, StopTime, Service, Trip, Group, Network
+from core import EventType, Group, Network, Service, Stop, StopTime, Trip
+from simulation import CarSetting, Simulation
 
 logger = logging.getLogger(__name__)
+BASE_DATE = date(2022, 1, 1)
 
 
 def run(simulation: Simulation, until: float):
@@ -36,7 +37,7 @@ def run_until_reserved(simulation: Simulation):
 
 class OneMobilityTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self.base_datetime = datetime.combine(date.today(), time())
+        self.base_datetime = datetime.combine(BASE_DATE, time())
         self.stop1 = Stop(stop_id="Stop1", name=..., lat=..., lng=...)
         self.stop2 = Stop(stop_id="Stop2", name=..., lat=..., lng=...)
         self.stop3 = Stop(stop_id="Stop3", name=..., lat=..., lng=...)
@@ -1857,7 +1858,7 @@ class OneMobilityTestCase(unittest.TestCase):
 
 class TwoMobilityTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        self.base_datetime = datetime.combine(date.today(), time())
+        self.base_datetime = datetime.combine(BASE_DATE, time())
         self.stop1 = Stop(stop_id="Stop1", name=..., lat=..., lng=...)
         self.stop2 = Stop(stop_id="Stop2", name=..., lat=..., lng=...)
         self.stop3 = Stop(stop_id="Stop3", name=..., lat=..., lng=...)

--- a/src/base_simulators/ondemand/test/test_mobility.py
+++ b/src/base_simulators/ondemand/test/test_mobility.py
@@ -1,15 +1,16 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import unittest
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from unittest import TestCase
 from unittest.mock import Mock
 
-from core import User, Stop, Group, Trip, Service, StopTime as flex_StopTime, Network
+from core import Group, Network, Service, Stop, Trip, User
+from core import StopTime as flex_StopTime
 from environment import Environment
-from mobility import Car, Route, StopTime, CarManager, CarSetting, Evaluation
+from mobility import Car, CarManager, CarSetting, Evaluation, Route, StopTime
 
-base_datetime = datetime(year=2022, month=1, day=1)
+base_datetime = datetime(year=2022, month=1, day=1, tzinfo=UTC)
 stops = [
     Stop(stop_id="S001", name=..., lat=..., lng=...),
     Stop(stop_id="S002", name=..., lat=..., lng=...),

--- a/src/base_simulators/ondemand/test/test_service.py
+++ b/src/base_simulators/ondemand/test/test_service.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import logging
+import unittest
 from datetime import date
 
 from core import Service

--- a/src/base_simulators/oneway/controller.py
+++ b/src/base_simulators/oneway/controller.py
@@ -3,15 +3,15 @@
 import io
 import logging
 import zipfile
+from typing import Annotated
 
 import aiohttp
 import fastapi
-
 from gbfs import GbfsFiles
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
-from mblib.jschema import spec, events
+from mblib.jschema import events, spec
 from mobility import ScooterParameter
 from operation.reduce_fluctuations import OperatorParameter
 from simulation import Simulation
@@ -62,7 +62,7 @@ def get_specification():
 
 
 @app.post("/upload", response_model=response.Message)
-def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
+def upload(upload_file: Annotated[fastapi.UploadFile, fastapi.File(...)]):
     try:
         file_table.put(upload_file)
     finally:
@@ -74,7 +74,7 @@ def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
 async def setup(settings: query.Setup):
     async with aiohttp.ClientSession() as session:
         ref = settings.input_files[0]
-        filename, data = await file_table.pop(
+        _filename, data = await file_table.pop(
             session, filename=ref.filename, url=ref.fetch_url
         )
         with zipfile.ZipFile(io.BytesIO(data)) as archive:

--- a/src/base_simulators/oneway/event.py
+++ b/src/base_simulators/oneway/event.py
@@ -2,12 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import typing
-
 import simpy
-
 from core import EventType, Mobility
-
 from location import Location
 
 
@@ -15,7 +11,7 @@ class Event:
     def __init__(self, event_type: EventType):
         self.event_type = event_type
 
-    def dumps(self) -> typing.Dict:
+    def dumps(self) -> dict:
         return {"eventType": self.event_type}
 
 
@@ -85,11 +81,11 @@ class ReserveFailedEvent(Event):
 class DepartedArrivedEvent(Event):
     def __init__(
         self,
-        event_type: typing.Union[EventType.DEPARTED, EventType.ARRIVED],
+        event_type: EventType.DEPARTED | EventType.ARRIVED,
         mobility: Mobility,
         location: Location,
-        user_id: str = None,
-        demand_id: str = None,
+        user_id: str | None = None,
+        demand_id: str | None = None,
     ):
         super().__init__(event_type=event_type)
         self.user_id = user_id
@@ -117,8 +113,8 @@ class DepartedEvent(DepartedArrivedEvent):
         self,
         mobility: Mobility,
         location: Location,
-        user_id: str = None,
-        demand_id: str = None,
+        user_id: str | None = None,
+        demand_id: str | None = None,
     ):
         super().__init__(EventType.DEPARTED, mobility, location, user_id, demand_id)
 
@@ -128,8 +124,8 @@ class ArrivedEvent(DepartedArrivedEvent):
         self,
         mobility: Mobility,
         location: Location,
-        user_id: str = None,
-        demand_id: str = None,
+        user_id: str | None = None,
+        demand_id: str | None = None,
     ):
         super().__init__(EventType.ARRIVED, mobility, location, user_id, demand_id)
 

--- a/src/base_simulators/oneway/gbfs.py
+++ b/src/base_simulators/oneway/gbfs.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import io
-import zipfile
 import json
+import zipfile
 
 
 def read_json_file(f):

--- a/src/base_simulators/oneway/jschema/query.py
+++ b/src/base_simulators/oneway/jschema/query.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel, AnyHttpUrl, model_validator
-
-from mblib.jschema.events import ReserveEvent, DepartEvent
+from mblib.jschema.events import DepartEvent, ReserveEvent
+from pydantic import AnyHttpUrl, BaseModel, model_validator
 
 
 class InputFilesItem(BaseModel):

--- a/src/base_simulators/oneway/jschema/response.py
+++ b/src/base_simulators/oneway/jschema/response.py
@@ -1,11 +1,10 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel
-
 import typing
 
 from mblib.jschema import response
-from mblib.jschema.events import ReservedEvent, DepartedEvent, ArrivedEvent
+from mblib.jschema.events import ArrivedEvent, DepartedEvent, ReservedEvent
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/base_simulators/oneway/location.py
+++ b/src/base_simulators/oneway/location.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import typing
-from logging import getLogger
 from functools import reduce
+from logging import getLogger
 
 from core import Location
 from mobility import Scooter
-
 
 logger = getLogger(__name__)
 
@@ -17,8 +16,8 @@ class Dock:
     """Entity that stores a mobility"""
 
     def __init__(self, mobility: Scooter = None):
-        self.reserved: typing.Optional[Scooter] = None
-        self.mobility: typing.Optional[Scooter] = mobility
+        self.reserved: Scooter | None = None
+        self.mobility: Scooter | None = mobility
 
     @property
     def is_available(self):

--- a/src/base_simulators/oneway/mobility.py
+++ b/src/base_simulators/oneway/mobility.py
@@ -7,7 +7,6 @@ import typing
 from logging import getLogger
 
 import simpy
-
 from core import Location, Mobility
 
 logger = getLogger(__name__)

--- a/src/base_simulators/oneway/operation/reduce_fluctuations.py
+++ b/src/base_simulators/oneway/operation/reduce_fluctuations.py
@@ -5,9 +5,8 @@ import logging
 import typing
 
 import simpy
-
 from core import calc_distance
-from event import EventQueue, DepartedEvent, ArrivedEvent
+from event import ArrivedEvent, DepartedEvent, EventQueue
 from location import Station
 
 logger = logging.getLogger(__name__)

--- a/src/base_simulators/oneway/simulation.py
+++ b/src/base_simulators/oneway/simulation.py
@@ -1,22 +1,21 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-import typing
+
+from collections import defaultdict
 from dataclasses import dataclass
 from logging import getLogger
-from collections import defaultdict
 
 import simpy
-
-from location import Station
-from mobility import Scooter, ScooterParameter
 from event import (
+    ArrivedEvent,
+    DepartedEvent,
+    EventQueue,
     ReservedEvent,
     ReserveFailedEvent,
-    DepartedEvent,
-    ArrivedEvent,
-    EventQueue,
 )
+from location import Station
+from mobility import Scooter, ScooterParameter
 from operation.reduce_fluctuations import (
     Manager,
     OperatedStation,
@@ -40,17 +39,17 @@ class Simulation:
         self.env = simpy.Environment()
         self.queue = EventQueue(env=self.env)
         self.operation = Manager(env=self.env)
-        self.stations: typing.Dict[str, Station] = {}
-        self._reservations: typing.Dict[str, Reservation] = {}
+        self.stations: dict[str, Station] = {}
+        self._reservations: dict[str, Reservation] = {}
 
     def setup(
         self,
-        station_information: typing.List[typing.Dict],
-        free_bike_status: typing.List[typing.Dict],
+        station_information: list[dict],
+        free_bike_status: list[dict],
         scooter_params: ScooterParameter,
         operator_params: OperatorParameter,
     ):
-        mobilities: typing.Dict[str, typing.List[Scooter]] = defaultdict(list)
+        mobilities: dict[str, list[Scooter]] = defaultdict(list)
         for bike in free_bike_status:
             mobilities[bike["station_id"]].append(
                 Scooter(

--- a/src/base_simulators/oneway/test/test_internal.py
+++ b/src/base_simulators/oneway/test/test_internal.py
@@ -1,12 +1,12 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import logging
+import unittest
 
-from simulation import Simulation
 from event import EventType
 from mobility import ScooterParameter
 from operation.reduce_fluctuations import OperatorParameter
+from simulation import Simulation
 
 logger = logging.getLogger(__name__)
 

--- a/src/base_simulators/routedeviation/controller.py
+++ b/src/base_simulators/routedeviation/controller.py
@@ -4,15 +4,15 @@ import datetime
 import io
 import logging
 import zipfile
+from typing import Annotated
 
 import aiohttp
 import fastapi
-
 import gtfs
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
-from mblib.jschema import spec, events
+from mblib.jschema import events, spec
 from simulation import Simulation
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def get_specification():
 
 
 @app.post("/upload")
-def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
+def upload(upload_file: Annotated[fastapi.UploadFile, fastapi.File(...)]):
     try:
         file_table.put(upload_file)
     finally:
@@ -73,7 +73,7 @@ def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
 async def setup(settings: query.Setup):
     async with aiohttp.ClientSession() as session:
         ref = settings.input_files[0]
-        filename, data = await file_table.pop(
+        _filename, data = await file_table.pop(
             session, filename=ref.filename, url=ref.fetch_url
         )
     with zipfile.ZipFile(io.BytesIO(data)) as archive:

--- a/src/base_simulators/routedeviation/core.py
+++ b/src/base_simulators/routedeviation/core.py
@@ -1,10 +1,11 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
-import typing
+
 import dataclasses
+import typing
+from datetime import date, datetime, time, timedelta
 from enum import Enum, auto
-from datetime import date, time, datetime, timedelta
 
 
 class EventType(str, Enum):
@@ -71,7 +72,10 @@ class StopTime:
     departure: timedelta
 
     def __init__(
-        self, stop: Stop, arrival: timedelta = None, departure: timedelta = None
+        self,
+        stop: Stop,
+        arrival: timedelta | None = None,
+        departure: timedelta | None = None,
     ):
         assert arrival or departure
         self.stop = stop
@@ -140,8 +144,8 @@ class Service:
     _start_day: date
     _end_day: date
     _weekday: tuple[bool, bool, bool, bool, bool, bool, bool]
-    _added_exceptions: typing.List[date]
-    _removed_exceptions: typing.List[date]
+    _added_exceptions: list[date]
+    _removed_exceptions: list[date]
 
     def __init__(
         self,
@@ -188,7 +192,7 @@ class Path:
     pick_up_stop: TemporaryStop | None = None
     drop_off_stop: TemporaryStop | None = None
 
-    def __lt__(self, other: "Path"):
+    def __lt__(self, other: Path):
         if not isinstance(other, Path):
             return NotImplementedError()
         return (
@@ -222,17 +226,17 @@ class Trip:
     """Sequence of two or more stops during a specific time period using a vehicle"""
 
     @property
-    def stops(self) -> typing.List[Stop]:
+    def stops(self) -> list[Stop]:
         raise NotImplementedError()
 
     def is_operation(self, at_date: date) -> bool:
         raise NotImplementedError()
 
-    def stop_times_at(self, at_date: date) -> typing.List[StopTimeWithDateTime]:
+    def stop_times_at(self, at_date: date) -> list[StopTimeWithDateTime]:
         raise NotImplementedError()
 
     def iter_stop_times_at(
-        self, at_date: date, users: typing.Dict[str, User]
+        self, at_date: date, users: dict[str, User]
     ) -> typing.Iterator[AbstractStopTimeWithDateTime]:
         raise NotImplementedError()
 
@@ -286,7 +290,7 @@ class Mobility:
     def stop(self) -> StopLike:
         raise NotImplementedError()
 
-    def trip(self, at: date = None) -> Trip | None:
+    def trip(self, at: date | None = None) -> Trip | None:
         if at is None:
             at = self.operation_date
 
@@ -308,15 +312,13 @@ class Mobility:
         today_date = date_time.date()
 
         before_date = today_date - timedelta(days=1)
-        if trip := self.trip(before_date):
+        if (trip := self.trip(before_date)) and date_time < trip.end_time(before_date):
             # If the previous day's operation has not been completed, returns the previous day's date.
-            if date_time < trip.end_time(before_date):
-                return before_date
+            return before_date
 
-        if trip := self.trip(today_date):
+        if (trip := self.trip(today_date)) and trip.end_time(today_date) <= date_time:
             # If today's operation has been completed, returns the next day's date.
-            if trip.end_time(today_date) <= date_time:
-                return date_time.date() + timedelta(days=1)
+            return date_time.date() + timedelta(days=1)
 
         return today_date
 

--- a/src/base_simulators/routedeviation/environment.py
+++ b/src/base_simulators/routedeviation/environment.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from logging import getLogger
 from datetime import datetime, timedelta
+from logging import getLogger
 
 from simpy import Environment as Original
 

--- a/src/base_simulators/routedeviation/event.py
+++ b/src/base_simulators/routedeviation/event.py
@@ -1,7 +1,5 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import typing
-
 
 from core import EventType, Mobility, User
 from environment import Environment
@@ -12,7 +10,7 @@ class TriggerEvent:
         self.event_type = event_type
         self.env = env
 
-    def dumps(self) -> typing.Dict:
+    def dumps(self) -> dict:
         return {"eventType": self.event_type, "time": self.env.now}
 
 
@@ -109,7 +107,7 @@ class ArrivedEvent(DepartedArrivedEvent):
 
 class EventQueue:
     def __init__(self):
-        self._events: typing.List[typing.Dict] = []
+        self._events: list[dict] = []
 
     @property
     def events(self):

--- a/src/base_simulators/routedeviation/gtfs.py
+++ b/src/base_simulators/routedeviation/gtfs.py
@@ -3,12 +3,12 @@
 import collections
 import csv
 import datetime
-import typing
 import io
-import zipfile
 import re
+import typing
+import zipfile
 
-from core import Agency, Stop, Route, StopTime, Service, TripLocation, AbstractStopTime
+from core import AbstractStopTime, Agency, Route, Service, Stop, StopTime, TripLocation
 from trip import SingleTrip
 
 p = re.compile(r"(\d\d?):(\d\d?):(\d\d?)")
@@ -24,13 +24,11 @@ def str_time(time: str):
 
 
 def str_date(time: str):
-    return datetime.datetime.strptime(time, "%Y%m%d").date()
+    return datetime.date.fromisoformat(f"{time[:4]}-{time[4:6]}-{time[6:8]}")
 
 
 class GtfsReader:
-    def __init__(
-        self, f, parse: typing.Callable[[typing.Dict[str, str]], typing.Tuple]
-    ):
+    def __init__(self, f, parse: typing.Callable[[dict[str, str]], tuple]):
         self.reader = csv.DictReader(io.TextIOWrapper(f, encoding="utf-8-sig"))
         self.parse = parse
 
@@ -41,7 +39,7 @@ class GtfsReader:
         return self.parse(next(self.reader))
 
 
-def parse_agency(row: typing.Dict[str, str]):
+def parse_agency(row: dict[str, str]):
     return row["agency_id"], Agency(
         agency_name=row["agency_name"],
         agency_url=row["agency_url"],
@@ -49,7 +47,7 @@ def parse_agency(row: typing.Dict[str, str]):
     )
 
 
-def parse_stop(row: typing.Dict[str, str]):
+def parse_stop(row: dict[str, str]):
     return row["stop_id"], Stop(
         stop_id=row["stop_id"],
         name=row["stop_name"],
@@ -58,7 +56,7 @@ def parse_stop(row: typing.Dict[str, str]):
     )
 
 
-def parse_calendar(row: typing.Dict[str, str]):
+def parse_calendar(row: dict[str, str]):
     return row["service_id"], Service(
         start_date=str_date(row["start_date"]),
         end_date=str_date(row["end_date"]),
@@ -72,23 +70,21 @@ def parse_calendar(row: typing.Dict[str, str]):
     )
 
 
-def parse_calendar_dates(row: typing.Dict[str, str]):
+def parse_calendar_dates(row: dict[str, str]):
     return row["service_id"], str_date(row["date"]), row["exception_type"] == "1"
 
 
 class GtfsFilesReader:
     def __init__(self, archive: zipfile.ZipFile):
-        self._agencies: typing.Dict[str, Agency] = {}
-        self.stops: typing.Dict[str, Stop] = {}
-        self._routes: typing.Dict[str, Route] = {}
-        self._stop_times: typing.Dict[str, typing.List[AbstractStopTime]] = (
-            collections.defaultdict(list)
+        self._agencies: dict[str, Agency] = {}
+        self.stops: dict[str, Stop] = {}
+        self._routes: dict[str, Route] = {}
+        self._stop_times: dict[str, list[AbstractStopTime]] = collections.defaultdict(
+            list
         )
-        self._services: typing.Dict[str, Service] = {}
-        self.trips: typing.Dict[str, SingleTrip] = {}
-        self.blocks: typing.Dict[str, typing.List[SingleTrip]] = (
-            collections.defaultdict(list)
-        )
+        self._services: dict[str, Service] = {}
+        self.trips: dict[str, SingleTrip] = {}
+        self.blocks: dict[str, list[SingleTrip]] = collections.defaultdict(list)
 
         with archive.open("agency.txt") as f:
             for k, v in GtfsReader(f, parse_agency):
@@ -126,7 +122,7 @@ class GtfsFilesReader:
                 else:
                     self.trips.update({k: v})
 
-    def parse_route(self, row: typing.Dict[str, str]):
+    def parse_route(self, row: dict[str, str]):
         return row["route_id"], Route(
             agency=self._agencies["agency_id"]
             if self._agencies.get("agency_id")
@@ -136,7 +132,7 @@ class GtfsFilesReader:
             route_type=row["route_type"],
         )
 
-    def parse_stop_time(self, row: typing.Dict[str, str]):
+    def parse_stop_time(self, row: dict[str, str]):
         if stop_id := row.get("stop_id"):
             return row["trip_id"], StopTime(
                 stop=self.stops[stop_id],
@@ -154,7 +150,7 @@ class GtfsFilesReader:
                 "not supported for on-demand bus service using location_group (use ondemand sim.)"
             )
 
-    def parse_trip(self, row: typing.Dict[str, str]):
+    def parse_trip(self, row: dict[str, str]):
         return row["trip_id"], SingleTrip(
             route=self._routes[row["route_id"]],
             service=self._services[row["service_id"]],

--- a/src/base_simulators/routedeviation/jschema/query.py
+++ b/src/base_simulators/routedeviation/jschema/query.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel, AnyHttpUrl, model_validator, conlist, constr
-
-from mblib.jschema.events import ReserveEvent, DepartEvent
+from mblib.jschema.events import DepartEvent, ReserveEvent
+from pydantic import AnyHttpUrl, BaseModel, conlist, constr, model_validator
 
 
 class Mobility(BaseModel):

--- a/src/base_simulators/routedeviation/jschema/response.py
+++ b/src/base_simulators/routedeviation/jschema/response.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel
 import typing
 
 from mblib.jschema import response
-from mblib.jschema.events import ReservedEvent, DepartedEvent, ArrivedEvent
+from mblib.jschema.events import ArrivedEvent, DepartedEvent, ReservedEvent
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/base_simulators/routedeviation/mobility.py
+++ b/src/base_simulators/routedeviation/mobility.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import typing
-from logging import getLogger
-from itertools import chain
 from datetime import datetime, time, timedelta
+from itertools import chain
+from logging import getLogger
 
-from core import Path, Trip, UserStatus, User, Mobility, StopLike
+from core import Mobility, Path, StopLike, Trip, User, UserStatus
 from environment import Environment
-from event import EventQueue, DepartedEvent, ArrivedEvent, ReservedEvent
+from event import ArrivedEvent, DepartedEvent, EventQueue, ReservedEvent
 
 logger = getLogger(__name__)
 
@@ -18,8 +18,8 @@ class Car(Mobility):
     env: Environment
     events: EventQueue
     _capacity: int
-    _stop: typing.Union[StopLike, None]
-    users: typing.Dict[
+    _stop: StopLike | None
+    users: dict[
         str, User
     ]  # 車両を予約している/停車駅に待機している/車両に乗車している すべての利用者
 
@@ -136,13 +136,13 @@ class Car(Mobility):
                 )
 
     def __str__(self):
-        data = dict(
-            now=self.env.now,
-            mobility_id=self.mobility_id,
-            trip=self._trip,
-            stop=self.stop,
-            users=tuple(self.users.values()),
-        )
+        data = {
+            "now": self.env.now,
+            "mobility_id": self.mobility_id,
+            "trip": self._trip,
+            "stop": self.stop,
+            "users": tuple(self.users.values()),
+        }
         return f"Car({data})"
 
     def reserve(self, user_id: str, demand_id: str, path: Path):
@@ -197,7 +197,7 @@ class CarManager:
     ):
         self.env = env
         self.event_queue = event_queue
-        self.mobilities: typing.Dict[str, Car] = {
+        self.mobilities: dict[str, Car] = {
             setting.mobility_id: Car(
                 env=self.env,
                 queue=self.event_queue,
@@ -220,7 +220,7 @@ class CarManager:
 
     def earliest_mobility(
         self, org: StopLike, dst: StopLike, dept: float
-    ) -> typing.Optional[Car]:
+    ) -> Car | None:
         """Return the vehicle that arrives at the destination earliest.
 
         Returns `None` If there is no vehicle available"""
@@ -237,4 +237,4 @@ class CarManager:
         if not len(car_arrivals):
             return None
 
-        return sorted(car_arrivals.items(), key=lambda x: x[1])[0][0]
+        return min(car_arrivals.items(), key=lambda x: x[1])[0]

--- a/src/base_simulators/routedeviation/simulation.py
+++ b/src/base_simulators/routedeviation/simulation.py
@@ -2,17 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import typing
 from datetime import datetime
 from logging import getLogger
 
-from mblib.jschema.events import Location
-
-from core import TemporaryStop, StopLike
+from core import StopLike, TemporaryStop
 from environment import Environment
 from event import EventQueue, ReserveFailedEvent
+from mblib.jschema.events import Location
 from mobility import CarManager, CarSetting
-from trip import SingleTrip, BlockTrip, Stop, TripLocation
+from trip import BlockTrip, SingleTrip, Stop, TripLocation
 
 logger = getLogger(__name__)
 
@@ -21,15 +19,15 @@ class Simulation:
     env: Environment
     event_queue: EventQueue
     car_manager: CarManager
-    stops: typing.Dict[str, Stop]
-    locations: typing.Dict[str, TripLocation]
+    stops: dict[str, Stop]
+    locations: dict[str, TripLocation]
 
     def __init__(
         self,
         start_time: datetime,
         capacity: int,
-        trips: typing.Dict[str, SingleTrip] = None,
-        blocks: typing.Dict[str, list[SingleTrip]] = None,
+        trips: dict[str, SingleTrip] | None = None,
+        blocks: dict[str, list[SingleTrip]] | None = None,
     ) -> None:
         trips = trips or {}
         blocks = blocks or {}

--- a/src/base_simulators/routedeviation/test/test_internal.py
+++ b/src/base_simulators/routedeviation/test/test_internal.py
@@ -1,15 +1,16 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import logging
-from datetime import datetime, date, time, timedelta
+import unittest
+from datetime import date, datetime, time, timedelta
 
-from simulation import Simulation
-from core import EventType, Stop, StopTime, Service
-from trip import SingleTrip, BlockTrip
+from core import EventType, Service, Stop, StopTime
 from mblib.jschema import events
+from simulation import Simulation
+from trip import BlockTrip, SingleTrip
 
 logger = logging.getLogger(__name__)
+BASE_DATE = date(2022, 1, 1)
 
 
 def run(simulation: Simulation, until: float):
@@ -50,14 +51,14 @@ class SingleTripTestCase(unittest.TestCase):
         self.mobility_id = "mobility"
 
         self.simulation = Simulation(
-            start_time=datetime.combine(date.today(), time()),
+            start_time=datetime.combine(BASE_DATE, time()),
             capacity=20,
             trips={
                 self.mobility_id: SingleTrip(
                     route=...,
                     service=Service(
-                        start_date=date.today(),
-                        end_date=date.today() + timedelta(days=1),
+                        start_date=BASE_DATE,
+                        end_date=BASE_DATE + timedelta(days=1),
                         monday=True,
                         tuesday=True,
                         wednesday=True,

--- a/src/base_simulators/routedeviation/test/test_service.py
+++ b/src/base_simulators/routedeviation/test/test_service.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import logging
+import unittest
 from datetime import date
 
 from core import Service

--- a/src/base_simulators/routedeviation/trip.py
+++ b/src/base_simulators/routedeviation/trip.py
@@ -1,25 +1,25 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
+import dataclasses
 import itertools
 import typing
-import dataclasses
-from datetime import date, timedelta, datetime, time
+from datetime import date, datetime, time, timedelta
 
 from core import (
-    Trip,
+    AbstractStopTime,
+    AbstractStopTimeWithDateTime,
+    DeviatedStopTimeWithDateTime,
+    Path,
     Route,
     Service,
-    StopTime,
     Stop,
-    StopTimeWithDateTime,
-    Path,
-    TripLocation,
-    DeviatedStopTimeWithDateTime,
-    TemporaryStop,
-    User,
-    AbstractStopTime,
     StopLike,
-    AbstractStopTimeWithDateTime,
+    StopTime,
+    StopTimeWithDateTime,
+    TemporaryStop,
+    Trip,
+    TripLocation,
+    User,
 )
 
 T = typing.TypeVar("T")
@@ -34,7 +34,7 @@ def _triplewise(it: typing.Iterable[T]):
 
 
 def _find_stop(
-    stop_times_with: typing.List[AbstractStopTime], stop: Stop, at_date: date
+    stop_times_with: list[AbstractStopTime], stop: Stop, at_date: date
 ) -> typing.Iterator[StopTimeWithDateTime]:
     for stop_time in stop_times_with:
         match stop_time:
@@ -44,7 +44,7 @@ def _find_stop(
 
 
 def _find_location(
-    stop_times_with: typing.List[AbstractStopTime], loc: TripLocation, at_date: date
+    stop_times_with: list[AbstractStopTime], loc: TripLocation, at_date: date
 ) -> typing.Iterator[tuple[StopTimeWithDateTime, StopTimeWithDateTime]]:
     for loc1, loc2, loc3 in _triplewise(stop_times_with):
         match loc2:
@@ -63,8 +63,8 @@ def _find_location(
 
 
 def _find_org(
-    stop_times_with: typing.List[AbstractStopTime], org: StopLike, at: date
-) -> typing.Iterator[typing.Tuple[StopTimeWithDateTime, TemporaryStop | None]]:
+    stop_times_with: list[AbstractStopTime], org: StopLike, at: date
+) -> typing.Iterator[tuple[StopTimeWithDateTime, TemporaryStop | None]]:
     match org:
         case Stop() as p:
             for stop in _find_stop(stop_times_with, p, at):
@@ -77,8 +77,8 @@ def _find_org(
 
 
 def _find_dst(
-    stop_times_with: typing.List[AbstractStopTime], dst: StopLike, at: date
-) -> typing.Iterator[typing.Tuple[TemporaryStop | None, StopTimeWithDateTime]]:
+    stop_times_with: list[AbstractStopTime], dst: StopLike, at: date
+) -> typing.Iterator[tuple[TemporaryStop | None, StopTimeWithDateTime]]:
     match dst:
         case Stop() as p:
             for stop in _find_stop(stop_times_with, p, at):
@@ -91,7 +91,7 @@ def _find_dst(
 
 
 def _get_paths(
-    stop_times_with: typing.List[AbstractStopTime],
+    stop_times_with: list[AbstractStopTime],
     org: StopLike,
     dst: StopLike,
     at: date,
@@ -112,16 +112,19 @@ def get_deviated_stops(
     departure: timedelta,
     arrival: timedelta,
     at_date: date,
-    users: typing.Dict[str, User],
-) -> typing.List[DeviatedStopTimeWithDateTime]:
-    tstops: typing.List[TemporaryStop] = []
+    users: dict[str, User],
+) -> list[DeviatedStopTimeWithDateTime]:
+    tstops: list[TemporaryStop] = []
     for user in users.values():
-        if tstop := user.path.pick_up_stop:  # if pick up on deviated route
-            if tstop.location.location_id == location_id:
-                tstops.append(tstop)
-        if tstop := user.path.drop_off_stop:  # if drop off on deviated route
-            if tstop.location.location_id == location_id:
-                tstops.append(tstop)
+        if (
+            tstop := user.path.pick_up_stop
+        ) and tstop.location.location_id == location_id:  # if pick up on deviated route
+            tstops.append(tstop)
+        if (
+            (tstop := user.path.drop_off_stop)
+            and tstop.location.location_id == location_id
+        ):  # if drop off on deviated route
+            tstops.append(tstop)
     if not tstops:
         return []
     dt_initial = datetime.combine(at_date, time()) + departure
@@ -139,7 +142,7 @@ class SingleTrip(Trip):
 
     route: Route
     service: Service
-    stop_times_with: typing.List[AbstractStopTime]
+    stop_times_with: list[AbstractStopTime]
     block_id: str = ""
 
     def __post_init__(self):
@@ -148,7 +151,7 @@ class SingleTrip(Trip):
         assert isinstance(self.stop_times_with[-1], StopTime)
 
     @property
-    def stop_times(self) -> typing.List[StopTime]:
+    def stop_times(self) -> list[StopTime]:
         return [
             stop_time
             for stop_time in self.stop_times_with
@@ -156,7 +159,7 @@ class SingleTrip(Trip):
         ]
 
     @property
-    def locations(self) -> typing.List[TripLocation]:
+    def locations(self) -> list[TripLocation]:
         return [
             stop_time
             for stop_time in self.stop_times_with
@@ -164,20 +167,20 @@ class SingleTrip(Trip):
         ]
 
     @property
-    def stops(self) -> typing.List[Stop]:
+    def stops(self) -> list[Stop]:
         return [stop_time.stop for stop_time in self.stop_times]
 
     def is_operation(self, at: date) -> bool:
         return self.service.is_operation(at)
 
-    def stop_times_at(self, at_date: date) -> typing.List[StopTimeWithDateTime]:
+    def stop_times_at(self, at_date: date) -> list[StopTimeWithDateTime]:
         return [
             StopTimeWithDateTime(stop_time=stop_time, reference_date=at_date)
             for stop_time in self.stop_times
         ]
 
     def iter_stop_times_at(
-        self, at_date: date, users: typing.Dict[str, User]
+        self, at_date: date, users: dict[str, User]
     ) -> typing.Iterator[AbstractStopTimeWithDateTime]:
         yield StopTimeWithDateTime(
             stop_time=self.stop_times_with[0], reference_date=at_date
@@ -200,7 +203,7 @@ class SingleTrip(Trip):
         )
 
     def start_time(self, at: date):
-        return list(self.stop_times_at(at))[0].arrival
+        return next(iter(self.stop_times_at(at))).arrival
 
     def end_time(self, at: date):
         return list(self.stop_times_at(at))[-1].departure
@@ -218,11 +221,11 @@ class SingleTrip(Trip):
 class BlockTrip(Trip):
     """Sequence of trips which belong to a block"""
 
-    trips: typing.List[SingleTrip]
+    trips: list[SingleTrip]
 
     def __post_init__(self):
         assert len(self.trips) >= 2
-        assert len(set(trip.block_id for trip in self.trips)) <= 1
+        assert len({trip.block_id for trip in self.trips}) <= 1
         assert self.trips[0].block_id != ""
 
         # The following assertion is generally true for most cases,
@@ -232,7 +235,7 @@ class BlockTrip(Trip):
         )
 
     @property
-    def stop_times(self) -> typing.List[StopTime]:
+    def stop_times(self) -> list[StopTime]:
         return [
             stop_time
             for trip in self.trips
@@ -241,7 +244,7 @@ class BlockTrip(Trip):
         ]
 
     @property
-    def locations(self) -> typing.List[TripLocation]:
+    def locations(self) -> list[TripLocation]:
         return [
             stop_time
             for trip in self.trips
@@ -250,11 +253,11 @@ class BlockTrip(Trip):
         ]
 
     @property
-    def stops(self) -> typing.List[Stop]:
+    def stops(self) -> list[Stop]:
         return [stop_time.stop for trip in self.trips for stop_time in trip.stop_times]
 
     def is_operation(self, at: date) -> bool:
-        return any([trip.service.is_operation(at) for trip in self.trips])
+        return any(trip.service.is_operation(at) for trip in self.trips)
 
     def stop_times_at(self, at: date):
         # Depending on the service configuration, a block trip can be split into multiple trips
@@ -268,7 +271,7 @@ class BlockTrip(Trip):
         ]
 
     def iter_stop_times_at(
-        self, at_date: date, users: typing.Dict[str, User]
+        self, at_date: date, users: dict[str, User]
     ) -> typing.Iterator[AbstractStopTimeWithDateTime]:
         stop_times_with = self.stop_times_with(at_date)
         yield StopTimeWithDateTime(stop_time=stop_times_with[0], reference_date=at_date)
@@ -289,7 +292,7 @@ class BlockTrip(Trip):
             stop_time=stop_times_with[-1], reference_date=at_date
         )
 
-    def stop_times_with(self, at: date) -> typing.List[AbstractStopTime]:
+    def stop_times_with(self, at: date) -> list[AbstractStopTime]:
         return [
             stop_time
             for trip in self.trips
@@ -298,7 +301,7 @@ class BlockTrip(Trip):
         ]
 
     def start_time(self, at: date):
-        return list(self.stop_times_at(at))[0].arrival
+        return next(iter(self.stop_times_at(at))).arrival
 
     def end_time(self, at: date):
         return list(self.stop_times_at(at))[-1].departure

--- a/src/base_simulators/scheduled/controller.py
+++ b/src/base_simulators/scheduled/controller.py
@@ -4,15 +4,15 @@ import datetime
 import io
 import logging
 import zipfile
+from typing import Annotated
 
 import aiohttp
 import fastapi
-
 import gtfs
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
-from mblib.jschema import spec, events
+from mblib.jschema import events, spec
 from simulation import Simulation
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ def get_specification():
 
 
 @app.post("/upload")
-def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
+def upload(upload_file: Annotated[fastapi.UploadFile, fastapi.File(...)]):
     try:
         file_table.put(upload_file)
     finally:
@@ -73,7 +73,7 @@ def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
 async def setup(settings: query.Setup):
     async with aiohttp.ClientSession() as session:
         ref = settings.input_files[0]
-        filename, data = await file_table.pop(
+        _filename, data = await file_table.pop(
             session, filename=ref.filename, url=ref.fetch_url
         )
     with zipfile.ZipFile(io.BytesIO(data)) as archive:

--- a/src/base_simulators/scheduled/core.py
+++ b/src/base_simulators/scheduled/core.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import typing
 import dataclasses
+import typing
+from datetime import date, datetime, time, timedelta
 from enum import Enum, auto
-from datetime import date, time, datetime, timedelta
 
 
 class EventType(str, Enum):
@@ -55,7 +55,10 @@ class StopTime:
     departure: timedelta
 
     def __init__(
-        self, stop: Stop, arrival: timedelta = None, departure: timedelta = None
+        self,
+        stop: Stop,
+        arrival: timedelta | None = None,
+        departure: timedelta | None = None,
     ):
         assert arrival or departure
         self.stop = stop
@@ -91,8 +94,8 @@ class Service:
     _start_day: date
     _end_day: date
     _weekday: tuple[bool, bool, bool, bool, bool, bool, bool]
-    _added_exceptions: typing.List[date]
-    _removed_exceptions: typing.List[date]
+    _added_exceptions: list[date]
+    _removed_exceptions: list[date]
 
     def __init__(
         self,
@@ -171,13 +174,13 @@ class Trip:
     """Sequence of two or more stops during a specific time period using a vehicle"""
 
     @property
-    def stops(self) -> typing.List[Stop]:
+    def stops(self) -> list[Stop]:
         raise NotImplementedError()
 
     def is_operation(self, at_date: date) -> bool:
         raise NotImplementedError()
 
-    def stop_times_at(self, at_date: date) -> typing.List[StopTimeWithDateTime]:
+    def stop_times_at(self, at_date: date) -> list[StopTimeWithDateTime]:
         raise NotImplementedError()
 
     def start_time(self, at: date) -> datetime:
@@ -227,7 +230,7 @@ class Mobility:
     def stop(self) -> Stop:
         raise NotImplementedError()
 
-    def trip(self, at: date = None):
+    def trip(self, at: date | None = None):
         if at is None:
             at = self.operation_date
 
@@ -249,19 +252,16 @@ class Mobility:
         today_date = date_time.date()
 
         before_date = today_date - timedelta(days=1)
-        if trip := self.trip(before_date):
+        if (trip := self.trip(before_date)) and date_time < trip.end_time(before_date):
             # If the previous day's operation has not been completed, returns the previous day's date.
-            if date_time < trip.end_time(before_date):
-                return before_date
+            return before_date
 
-        if trip := self.trip(today_date):
+        if (trip := self.trip(today_date)) and trip.end_time(today_date) <= date_time:
             # If today's operation has been completed, returns the next day's date.
-            if trip.end_time(today_date) <= date_time:
-                return date_time.date() + timedelta(days=1)
+            return date_time.date() + timedelta(days=1)
 
         return today_date
 
     def paths(self, org: Stop, dst: Stop, at: date):
         if trip := self.trip(at):
-            for path in trip.paths(org, dst, at):
-                yield path
+            yield from trip.paths(org, dst, at)

--- a/src/base_simulators/scheduled/environment.py
+++ b/src/base_simulators/scheduled/environment.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from logging import getLogger
 from datetime import datetime, timedelta
+from logging import getLogger
 
 from simpy import Environment as Original
 

--- a/src/base_simulators/scheduled/event.py
+++ b/src/base_simulators/scheduled/event.py
@@ -1,7 +1,5 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import typing
-
 
 from core import EventType, Mobility, User
 from environment import Environment
@@ -12,7 +10,7 @@ class TriggerEvent:
         self.event_type = event_type
         self.env = env
 
-    def dumps(self) -> typing.Dict:
+    def dumps(self) -> dict:
         return {"eventType": self.event_type, "time": self.env.now}
 
 
@@ -109,7 +107,7 @@ class ArrivedEvent(DepartedArrivedEvent):
 
 class EventQueue:
     def __init__(self):
-        self._events: typing.List[typing.Dict] = []
+        self._events: list[dict] = []
 
     @property
     def events(self):

--- a/src/base_simulators/scheduled/gtfs.py
+++ b/src/base_simulators/scheduled/gtfs.py
@@ -3,12 +3,12 @@
 import collections
 import csv
 import datetime
-import typing
 import io
-import zipfile
 import re
+import typing
+import zipfile
 
-from core import Agency, Stop, Route, StopTime, Service
+from core import Agency, Route, Service, Stop, StopTime
 from trip import SingleTrip
 
 p = re.compile(r"(\d\d?):(\d\d?):(\d\d?)")
@@ -24,13 +24,11 @@ def str_time(time: str):
 
 
 def str_date(time: str):
-    return datetime.datetime.strptime(time, "%Y%m%d").date()
+    return datetime.date.fromisoformat(f"{time[:4]}-{time[4:6]}-{time[6:8]}")
 
 
 class GtfsReader:
-    def __init__(
-        self, f, parse: typing.Callable[[typing.Dict[str, str]], typing.Tuple]
-    ):
+    def __init__(self, f, parse: typing.Callable[[dict[str, str]], tuple]):
         self.reader = csv.DictReader(io.TextIOWrapper(f, encoding="utf-8-sig"))
         self.parse = parse
 
@@ -41,7 +39,7 @@ class GtfsReader:
         return self.parse(next(self.reader))
 
 
-def parse_agency(row: typing.Dict[str, str]):
+def parse_agency(row: dict[str, str]):
     return row["agency_id"], Agency(
         agency_name=row["agency_name"],
         agency_url=row["agency_url"],
@@ -49,7 +47,7 @@ def parse_agency(row: typing.Dict[str, str]):
     )
 
 
-def parse_stop(row: typing.Dict[str, str]):
+def parse_stop(row: dict[str, str]):
     return row["stop_id"], Stop(
         stop_id=row["stop_id"],
         name=row["stop_name"],
@@ -58,7 +56,7 @@ def parse_stop(row: typing.Dict[str, str]):
     )
 
 
-def parse_calendar(row: typing.Dict[str, str]):
+def parse_calendar(row: dict[str, str]):
     return row["service_id"], Service(
         start_date=str_date(row["start_date"]),
         end_date=str_date(row["end_date"]),
@@ -72,23 +70,19 @@ def parse_calendar(row: typing.Dict[str, str]):
     )
 
 
-def parse_calendar_dates(row: typing.Dict[str, str]):
+def parse_calendar_dates(row: dict[str, str]):
     return row["service_id"], str_date(row["date"]), row["exception_type"] == "1"
 
 
 class GtfsFilesReader:
     def __init__(self, archive: zipfile.ZipFile):
-        self._agencies: typing.Dict[str, Agency] = {}
-        self.stops: typing.Dict[str, Stop] = {}
-        self._routes: typing.Dict[str, Route] = {}
-        self._stop_times: typing.Dict[str, typing.List[StopTime]] = (
-            collections.defaultdict(list)
-        )
-        self._services: typing.Dict[str, Service] = {}
-        self.trips: typing.Dict[str, SingleTrip] = {}
-        self.blocks: typing.Dict[str, typing.List[SingleTrip]] = (
-            collections.defaultdict(list)
-        )
+        self._agencies: dict[str, Agency] = {}
+        self.stops: dict[str, Stop] = {}
+        self._routes: dict[str, Route] = {}
+        self._stop_times: dict[str, list[StopTime]] = collections.defaultdict(list)
+        self._services: dict[str, Service] = {}
+        self.trips: dict[str, SingleTrip] = {}
+        self.blocks: dict[str, list[SingleTrip]] = collections.defaultdict(list)
 
         with archive.open("agency.txt") as f:
             for k, v in GtfsReader(f, parse_agency):
@@ -123,7 +117,7 @@ class GtfsFilesReader:
                 else:
                     self.trips.update({k: v})
 
-    def parse_route(self, row: typing.Dict[str, str]):
+    def parse_route(self, row: dict[str, str]):
         return row["route_id"], Route(
             agency=self._agencies["agency_id"]
             if self._agencies.get("agency_id")
@@ -133,14 +127,14 @@ class GtfsFilesReader:
             route_type=row["route_type"],
         )
 
-    def parse_stop_time(self, row: typing.Dict[str, str]):
+    def parse_stop_time(self, row: dict[str, str]):
         return row["trip_id"], StopTime(
             stop=self.stops[row["stop_id"]],
             arrival=str_time(row["arrival_time"]),
             departure=str_time(row["departure_time"]),
         )
 
-    def parse_trip(self, row: typing.Dict[str, str]):
+    def parse_trip(self, row: dict[str, str]):
         return row["trip_id"], SingleTrip(
             route=self._routes[row["route_id"]],
             service=self._services[row["service_id"]],

--- a/src/base_simulators/scheduled/jschema/query.py
+++ b/src/base_simulators/scheduled/jschema/query.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel, AnyHttpUrl, model_validator, conlist, constr
-
-from mblib.jschema.events import ReserveEvent, DepartEvent
+from mblib.jschema.events import DepartEvent, ReserveEvent
+from pydantic import AnyHttpUrl, BaseModel, conlist, constr, model_validator
 
 
 class Mobility(BaseModel):

--- a/src/base_simulators/scheduled/jschema/response.py
+++ b/src/base_simulators/scheduled/jschema/response.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel
 import typing
 
 from mblib.jschema import response
-from mblib.jschema.events import ReservedEvent, DepartedEvent, ArrivedEvent
+from mblib.jschema.events import ArrivedEvent, DepartedEvent, ReservedEvent
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/base_simulators/scheduled/mobility.py
+++ b/src/base_simulators/scheduled/mobility.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import typing
-from logging import getLogger
-from itertools import chain
 from datetime import datetime, time, timedelta
+from itertools import chain
+from logging import getLogger
 
-from core import Path, Trip, Stop, UserStatus, User, Mobility
+from core import Mobility, Path, Stop, Trip, User, UserStatus
 from environment import Environment
-from event import EventQueue, DepartedEvent, ArrivedEvent, ReservedEvent
+from event import ArrivedEvent, DepartedEvent, EventQueue, ReservedEvent
 
 logger = getLogger(__name__)
 
@@ -27,8 +27,8 @@ class Car(Mobility):
         self.env = env
         self.events = queue
         self._capacity = capacity
-        self._stop: typing.Optional[Stop] = None
-        self.users: typing.Dict[
+        self._stop: Stop | None = None
+        self.users: dict[
             str, User
         ] = {}  # 車両を予約している/停車駅に待機している/車両に乗車している すべての利用者
 
@@ -134,13 +134,13 @@ class Car(Mobility):
                 )
 
     def __str__(self):
-        data = dict(
-            now=self.env.now,
-            mobility_id=self.mobility_id,
-            trip=self._trip,
-            stop=self.stop,
-            users=tuple(self.users.values()),
-        )
+        data = {
+            "now": self.env.now,
+            "mobility_id": self.mobility_id,
+            "trip": self._trip,
+            "stop": self.stop,
+            "users": tuple(self.users.values()),
+        }
         return f"Car({data})"
 
     def reserve(self, user_id: str, demand_id: str, path: Path):
@@ -194,7 +194,7 @@ class CarManager:
     ):
         self.env = env
         self.event_queue = event_queue
-        self.mobilities: typing.Dict[str, Car] = {
+        self.mobilities: dict[str, Car] = {
             setting.mobility_id: Car(
                 env=self.env,
                 queue=self.event_queue,
@@ -215,9 +215,7 @@ class CarManager:
         for car in self.mobilities.values():
             self.env.process(car.run())
 
-    def earliest_mobility(
-        self, org: Stop, dst: Stop, dept: float
-    ) -> typing.Optional[Car]:
+    def earliest_mobility(self, org: Stop, dst: Stop, dept: float) -> Car | None:
         """Return the vehicle that arrives at the destination earliest.
 
         Returns `None` If there is no vehicle available"""
@@ -234,4 +232,4 @@ class CarManager:
         if not len(car_arrivals):
             return None
 
-        return sorted(car_arrivals.items(), key=lambda x: x[1])[0][0]
+        return min(car_arrivals.items(), key=lambda x: x[1])[0]

--- a/src/base_simulators/scheduled/simulation.py
+++ b/src/base_simulators/scheduled/simulation.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import typing
 from datetime import datetime
 from logging import getLogger
 
 from environment import Environment
 from event import EventQueue, ReserveFailedEvent
 from mobility import CarManager, CarSetting
-from trip import SingleTrip, BlockTrip
+from trip import BlockTrip, SingleTrip
 
 logger = getLogger(__name__)
 
@@ -19,8 +18,8 @@ class Simulation:
         self,
         start_time: datetime,
         capacity: int,
-        trips: typing.Dict[str, SingleTrip] = None,
-        blocks: typing.Dict[str, list[SingleTrip]] = None,
+        trips: dict[str, SingleTrip] | None = None,
+        blocks: dict[str, list[SingleTrip]] | None = None,
     ) -> None:
         trips = trips or {}
         blocks = blocks or {}

--- a/src/base_simulators/scheduled/test/test_internal.py
+++ b/src/base_simulators/scheduled/test/test_internal.py
@@ -1,14 +1,15 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import logging
-from datetime import datetime, date, time, timedelta
+import unittest
+from datetime import date, datetime, time, timedelta
 
+from core import EventType, Service, Stop, StopTime
 from simulation import Simulation
-from core import EventType, Stop, StopTime, Service
-from trip import SingleTrip, BlockTrip
+from trip import BlockTrip, SingleTrip
 
 logger = logging.getLogger(__name__)
+BASE_DATE = date(2022, 1, 1)
 
 
 def run(simulation: Simulation, until: float):
@@ -44,14 +45,14 @@ class SingleTripTestCase(unittest.TestCase):
         self.mobility_id = "mobility"
 
         self.simulation = Simulation(
-            start_time=datetime.combine(date.today(), time()),
+            start_time=datetime.combine(BASE_DATE, time()),
             capacity=20,
             trips={
                 self.mobility_id: SingleTrip(
                     route=...,
                     service=Service(
-                        start_date=date.today(),
-                        end_date=date.today() + timedelta(days=1),
+                        start_date=BASE_DATE,
+                        end_date=BASE_DATE + timedelta(days=1),
                         monday=True,
                         tuesday=True,
                         wednesday=True,

--- a/src/base_simulators/scheduled/test/test_service.py
+++ b/src/base_simulators/scheduled/test/test_service.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import unittest
 import logging
+import unittest
 from datetime import date
 
 from core import Service

--- a/src/base_simulators/scheduled/trip.py
+++ b/src/base_simulators/scheduled/trip.py
@@ -1,10 +1,9 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import typing
 import dataclasses
 from datetime import date
 
-from core import Trip, Route, Service, StopTime, Stop, StopTimeWithDateTime, Path
+from core import Path, Route, Service, Stop, StopTime, StopTimeWithDateTime, Trip
 
 
 @dataclasses.dataclass(frozen=True)
@@ -13,14 +12,14 @@ class SingleTrip(Trip):
 
     route: Route
     service: Service
-    stop_times: typing.List[StopTime]
+    stop_times: list[StopTime]
     block_id: str = ""
 
     def __post_init__(self):
         assert len(self.stop_times) >= 2
 
     @property
-    def stops(self) -> typing.List[Stop]:
+    def stops(self) -> list[Stop]:
         return [stop_time.stop for stop_time in self.stop_times]
 
     def is_operation(self, at: date) -> bool:
@@ -33,7 +32,7 @@ class SingleTrip(Trip):
         ]
 
     def start_time(self, at: date):
-        return list(self.stop_times_at(at))[0].arrival
+        return next(iter(self.stop_times_at(at))).arrival
 
     def end_time(self, at: date):
         return list(self.stop_times_at(at))[-1].departure
@@ -57,11 +56,11 @@ class SingleTrip(Trip):
 class BlockTrip(Trip):
     """Sequence of trips which belong to a block"""
 
-    trips: typing.List[SingleTrip]
+    trips: list[SingleTrip]
 
     def __post_init__(self):
         assert len(self.trips) >= 2
-        assert len(set(trip.block_id for trip in self.trips)) <= 1
+        assert len({trip.block_id for trip in self.trips}) <= 1
         assert self.trips[0].block_id != ""
 
         # The following assertion is generally true for most cases,
@@ -71,11 +70,11 @@ class BlockTrip(Trip):
         )
 
     @property
-    def stops(self) -> typing.List[Stop]:
+    def stops(self) -> list[Stop]:
         return [stop_time.stop for trip in self.trips for stop_time in trip.stop_times]
 
     def is_operation(self, at: date) -> bool:
-        return any([trip.service.is_operation(at) for trip in self.trips])
+        return any(trip.service.is_operation(at) for trip in self.trips)
 
     def stop_times_at(self, at: date):
         # Depending on the service configuration, a block trip can be split into multiple trips
@@ -89,7 +88,7 @@ class BlockTrip(Trip):
         ]
 
     def start_time(self, at: date):
-        return list(self.stop_times_at(at))[0].arrival
+        return next(iter(self.stop_times_at(at))).arrival
 
     def end_time(self, at: date):
         return list(self.stop_times_at(at))[-1].departure

--- a/src/base_simulators/walking/controller.py
+++ b/src/base_simulators/walking/controller.py
@@ -4,7 +4,6 @@ import logging
 import math
 
 import fastapi
-
 from core import Location
 from jschema import query, response
 from mblib.io.log import init_logger

--- a/src/base_simulators/walking/event.py
+++ b/src/base_simulators/walking/event.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
 
-from core import Location, EventType
+from core import EventType, Location
 
 
 @dataclasses.dataclass

--- a/src/base_simulators/walking/jschema/query.py
+++ b/src/base_simulators/walking/jschema/query.py
@@ -1,9 +1,8 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from mblib.jschema.events import DepartEvent, ReserveEvent
 from pydantic import BaseModel
-
-from mblib.jschema.events import ReserveEvent, DepartEvent
 
 
 class Setup(BaseModel):

--- a/src/base_simulators/walking/jschema/response.py
+++ b/src/base_simulators/walking/jschema/response.py
@@ -1,8 +1,7 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
+from mblib.jschema.events import ArrivedEvent, DepartedEvent, ReservedEvent
 from pydantic import BaseModel
-
-from mblib.jschema.events import ReservedEvent, DepartedEvent, ArrivedEvent
 
 
 class Message(BaseModel):

--- a/src/base_simulators/walking/simulation.py
+++ b/src/base_simulators/walking/simulation.py
@@ -4,10 +4,9 @@ import logging
 from dataclasses import dataclass
 
 import simpy
-from geopy.distance import geodesic
-
 from core import Location
-from event import ReservedEvent, DepartedEvent, ArrivedEvent
+from event import ArrivedEvent, DepartedEvent, ReservedEvent
+from geopy.distance import geodesic
 
 logger = logging.getLogger(__name__)
 MIN_DURATION = 0.0

--- a/src/evaluation/simple/controller.py
+++ b/src/evaluation/simple/controller.py
@@ -5,11 +5,10 @@ import math
 import pathlib
 
 import fastapi
-
 from core import Location
 from jschema import query, response
 from mblib.io.log import init_logger
-from mblib.io.result import ResultWriter, HTTPResultWriter, FileResultWriter
+from mblib.io.result import FileResultWriter, HTTPResultWriter, ResultWriter
 from mblib.jschema import events, spec
 from usability import UsabilityEvaluator
 
@@ -119,6 +118,7 @@ async def finish():
         manager = None
     if writer:
         await writer.close()
+        writer = None
     return response.Message(message="successfully finished.")
 
 

--- a/src/evaluation/simple/event.py
+++ b/src/evaluation/simple/event.py
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
 
-from simpy import Environment
-
 from core import Location
+from simpy import Environment
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/evaluation/simple/jschema/query.py
+++ b/src/evaluation/simple/jschema/query.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
-from pydantic import BaseModel, AnyHttpUrl, Field
 
 from mblib.jschema.events import DemandEvent
+from pydantic import AnyHttpUrl, BaseModel, Field
 
 
 class ResultWriterSetting(BaseModel):

--- a/src/evaluation/simple/planner.py
+++ b/src/evaluation/simple/planner.py
@@ -3,9 +3,8 @@
 import dataclasses
 
 import aiohttp
-
-from mblib.io import httputil
 from core import Location
+from mblib.io import httputil
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/evaluation/simple/test/test_usability.py
+++ b/src/evaluation/simple/test/test_usability.py
@@ -5,11 +5,12 @@ import pathlib
 import unittest
 import unittest.mock
 
+from core import Location
 from jschema.query import EvaluationTiming
 from mblib.io.result import FileResultWriter
-from core import Location
-from planner import Route, Trip
 from usability import UsabilityEvaluator
+
+from planner import Route, Trip
 
 logger = logging.getLogger(__name__)
 

--- a/src/evaluation/simple/usability.py
+++ b/src/evaluation/simple/usability.py
@@ -3,12 +3,12 @@
 import dataclasses
 import json
 
+from event import DemandEvent, EventQueue
+from jschema.query import EvaluationTiming
+from mblib.io.result import ResultWriter
 from simpy import Environment
 
-from mblib.io.result import ResultWriter
-from planner import Location, Route, Planner, ReservableChecker
-from event import EventQueue, DemandEvent
-from jschema.query import EvaluationTiming
+from planner import Location, Planner, ReservableChecker, Route
 
 
 def near_locations(loc1: Location, loc2: Location, *, delta: float):

--- a/src/planner/opentripplanner/config.py
+++ b/src/planner/opentripplanner/config.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import pathlib
+
 from mblib.io.log import LogConfig
 
 

--- a/src/planner/opentripplanner/controller.py
+++ b/src/planner/opentripplanner/controller.py
@@ -1,27 +1,28 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import aiohttp
 import asyncio
 import contextlib
 import datetime
-import fastapi
 import io
 import json
 import logging
 import math
 import pathlib
-import subprocess
 import typing
 import zipfile
+from copy import deepcopy
+from typing import Annotated
+from urllib.parse import quote as urlquote
+from urllib.parse import urljoin
 
+import aiohttp
+import fastapi
 from config import env
 from core import Location, Path
-from copy import deepcopy
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
 from route_planner import OpenTripPlanner
-from urllib.parse import urljoin, quote as urlquote
 
 logger = logging.getLogger(__name__)
 app = fastapi.FastAPI(
@@ -50,7 +51,7 @@ def exception_callback(request: fastapi.Request, exc: Exception):
 file_table = httputil.FileManager()
 
 planner: OpenTripPlanner | None = None
-proc: subprocess.Popen | None = None
+proc: asyncio.subprocess.Process | None = None
 
 
 @app.on_event("shutdown")
@@ -59,8 +60,9 @@ async def shutdown_event():
     if planner:
         await planner.close()
         planner = None
-    if proc:
+    if proc and proc.returncode is None:
         proc.kill()
+        await proc.wait()
 
 
 @app.get("/gbfs/{zipname}/{filename}")
@@ -71,7 +73,7 @@ def get_gbfs(zipname: str, filename: str):
 
 
 @app.post("/upload", response_model=response.Message)
-def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
+def upload(upload_file: Annotated[fastapi.UploadFile, fastapi.File(...)]):
     try:
         file_table.put(upload_file)
     finally:
@@ -115,7 +117,7 @@ def update_config_files_for_gbfs(url_base: str):
             dir_gbfs = path_gbfs_json.parent
             # Get gbfs.json file path and URL
             gbfsname = dir_gbfs.relative_to(env.OPENTRIPPLANNER_GBFS_DIR)
-            url = urljoin(url_base, f"/gbfs/{str(gbfsname)}/gbfs.json")
+            url = urljoin(url_base, f"/gbfs/{gbfsname!s}/gbfs.json")
 
             # Set URL to gbfs.json for updaters element in router-config.json
             for updater in updaters:
@@ -134,7 +136,7 @@ def update_config_files_for_gbfs(url_base: str):
 
             # Set feed URL in each gbfs.json file
             with open_json_file_for_update(path_gbfs_json) as gbfs:
-                for language, item in gbfs["data"].items():
+                for item in gbfs["data"].values():
                     for feed in item["feeds"]:
                         name = feed["name"]
                         path_json = dir_gbfs / f"{name}.json"
@@ -144,7 +146,7 @@ def update_config_files_for_gbfs(url_base: str):
                                 fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR, msg
                             )
                         url = urljoin(
-                            url_base, f"/gbfs/{str(gbfsname)}/{name}.json"
+                            url_base, f"/gbfs/{gbfsname!s}/{name}.json"
                         )  # str型に変換
                         feed["url"] = url
 
@@ -154,10 +156,14 @@ async def get_walking_speed(setting: query.Setup):
     if walking_meters_per_minute is None:
         walk_speed = 1.33
         try:
-            with open(env.OPENTRIPPLANNER_VOLUME_DIR / "router-config.json", "r") as fd:
-                config = json.load(fd)
+            config_path = env.OPENTRIPPLANNER_VOLUME_DIR / "router-config.json"
+            config = await asyncio.to_thread(config_path.read_text, encoding="utf-8")
+            config = json.loads(config)
             walk_speed = config.get("routingDefaults", {}).get("walkSpeed", walk_speed)
-        except Exception:  # Default value if the file cannot be read
+        except (
+            OSError,
+            json.JSONDecodeError,
+        ):  # Default value if the file cannot be read
             logger.warning(
                 f"failed to read {env.OPENTRIPPLANNER_VOLUME_DIR}/router-config.json"
             )
@@ -170,7 +176,7 @@ async def deploy_otp_files(
 ):
     """deploy set of configuration files for OpenTripPlanner"""
     for ref in refs:
-        filename, data = await file_table.pop(
+        _filename, data = await file_table.pop(
             session, filename=ref.filename, url=ref.fetch_url
         )
         with zipfile.ZipFile(io.BytesIO(data)) as archive:
@@ -212,7 +218,7 @@ async def setup(request: fastapi.Request, setting: query.Setup):
     network_types = set()
     async with aiohttp.ClientSession() as session:
         await deploy_otp_files(session, setting.otp_config.input_files, diff_years)
-        for service, network in setting.networks.items():
+        for network in setting.networks.values():
             for ref in network.input_files:
                 network_types.add(network.type)
                 if network.type in ["gtfs", "gtfs_flex"]:
@@ -275,7 +281,7 @@ async def setup(request: fastapi.Request, setting: query.Setup):
         "--serve",
         env.OPENTRIPPLANNER_VOLUME_DIR,
     ]
-    proc = subprocess.Popen(command)
+    proc = await asyncio.create_subprocess_exec(*command)
     try:
         await asyncio.wait_for(
             planner_up(interval=5), timeout=env.OPENTRIPPLANNER_STARTUP_TIMEOUT
@@ -289,7 +295,7 @@ async def setup(request: fastapi.Request, setting: query.Setup):
 async def planner_up(interval: float):
     while not await planner.health():
         await asyncio.sleep(interval)
-        rc = proc.poll()
+        rc = proc.returncode
         if rc is not None:
             msg = f"failed to start OpenTripPlanner: returncode={rc}"
             raise fastapi.HTTPException(fastapi.status.HTTP_408_REQUEST_TIMEOUT, msg)
@@ -307,7 +313,7 @@ async def plan(
     org: query.LocationSetting,
     dst: query.LocationSetting,
     dept: float,
-    arrv: typing.Optional[float] = None,
+    arrv: float | None = None,
 ):
     org = Location(id_=org.locationId, lat=org.lat, lng=org.lng)
     dst = Location(id_=dst.locationId, lat=dst.lat, lng=dst.lng)
@@ -317,24 +323,26 @@ async def plan(
 
 @app.get("/graphiql")
 async def graphiql():
-    async with aiohttp.ClientSession() as session:
-        async with session.get(
-            f"http://localhost:{env.OPENTRIPPLANNER_PORT}/graphiql"
-        ) as resp:
-            return fastapi.Response(
-                content=await resp.read(),
-                status_code=resp.status,
-                headers=dict(resp.headers),
-            )
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(f"http://localhost:{env.OPENTRIPPLANNER_PORT}/graphiql") as resp,
+    ):
+        return fastapi.Response(
+            content=await resp.read(),
+            status_code=resp.status,
+            headers=dict(resp.headers),
+        )
 
 
 @app.post("/otp/routers/default/index/graphql")
 async def graphql(request: fastapi.Request):
-    async with aiohttp.ClientSession() as session:
-        async with session.post(
+    async with (
+        aiohttp.ClientSession() as session,
+        session.post(
             f"http://localhost:{env.OPENTRIPPLANNER_PORT}/otp/routers/default/index/graphql",
             json=await request.json(),
-        ) as resp:
-            return fastapi.responses.JSONResponse(
-                content=await resp.json(), status_code=resp.status
-            )
+        ) as resp,
+    ):
+        return fastapi.responses.JSONResponse(
+            content=await resp.json(), status_code=resp.status
+        )

--- a/src/planner/opentripplanner/core.py
+++ b/src/planner/opentripplanner/core.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
-import typing
 from functools import cache
 
 from geopy.distance import great_circle
@@ -30,7 +29,7 @@ class Trip:
 
 @dataclasses.dataclass(frozen=True)
 class Path:
-    trips: typing.List[Trip]
+    trips: list[Trip]
     walking_time_minutes: float
 
     @property

--- a/src/planner/opentripplanner/jschema/query.py
+++ b/src/planner/opentripplanner/jschema/query.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
 
-from pydantic import BaseModel, AnyHttpUrl, model_validator, conlist, constr
+from pydantic import AnyHttpUrl, BaseModel, conlist, constr, model_validator
 
 
 class LocationSetting(BaseModel):

--- a/src/planner/opentripplanner/jschema/response.py
+++ b/src/planner/opentripplanner/jschema/response.py
@@ -1,9 +1,8 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel
-
 from mblib.jschema import response
 from mblib.jschema.events import Event
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/planner/opentripplanner/route_planner.py
+++ b/src/planner/opentripplanner/route_planner.py
@@ -7,11 +7,11 @@ import math
 import re
 import typing
 
-from gql import Client, gql
-from gql.transport.aiohttp import AIOHTTPTransport, log as aiohttp_logger
 import aiohttp
-
 from core import Location, Path, Trip, calc_distance
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+from gql.transport.aiohttp import log as aiohttp_logger
 from jschema.response import DistanceMatrix
 
 logger = logging.getLogger(__name__)
@@ -73,9 +73,11 @@ class OpenTripPlanner:
 
     async def health(self):
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.get(f"{self.endpoint}/otp/actuators/health") as resp:
-                    result = await resp.json()
+            async with (
+                aiohttp.ClientSession() as session,
+                session.get(f"{self.endpoint}/otp/actuators/health") as resp,
+            ):
+                result = await resp.json()
             return result == {"status": "UP"}
         except aiohttp.ClientConnectionError:
             return False

--- a/src/planner/opentripplanner/test/test_otp.py
+++ b/src/planner/opentripplanner/test/test_otp.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import unittest
+
 # import datetime
 
 # from core import Location, Trip

--- a/src/planner/simple/controller.py
+++ b/src/planner/simple/controller.py
@@ -3,12 +3,11 @@
 import datetime
 import io
 import logging
-import typing
 import zipfile
+from typing import Annotated
 
 import aiohttp
 import fastapi
-
 from core import Location, MobilityNetwork, WalkingNetwork
 from gbfs.network import Network as GbfsNetwork
 from gbfs.reader import FilesReader as GbfsFiles
@@ -19,7 +18,7 @@ from gtfs_flex.reader import FilesReader as GtfsFlexFiles
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
-from route_planner import Planner, DirectPathPlanner
+from route_planner import DirectPathPlanner, Planner
 
 logger = logging.getLogger(__name__)
 app = fastapi.FastAPI(
@@ -50,7 +49,7 @@ planner: Planner | None = None
 
 
 @app.post("/upload")
-async def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
+async def upload(upload_file: Annotated[fastapi.UploadFile, fastapi.File(...)]):
     try:
         file_table.put(upload_file)
     finally:
@@ -60,17 +59,19 @@ async def upload(upload_file: fastapi.UploadFile = fastapi.File(...)):
 
 @app.post("/setup", response_model=response.Message)
 async def setup(settings: query.Setup):
-    networks: typing.List[MobilityNetwork] = [
+    networks: list[MobilityNetwork] = [
         WalkingNetwork(
             "walking", walking_meters_per_minute=settings.walking_meters_per_minute
         )
     ]
-    start_time = datetime.datetime.strptime(settings.reference_time, "%Y%m%d")
+    start_time = datetime.datetime.strptime(settings.reference_time, "%Y%m%d").replace(
+        tzinfo=datetime.timezone.utc
+    )
     async with aiohttp.ClientSession() as session:
         for name, setting in settings.networks.items():
             if setting.type == "gbfs":
                 ref = setting.input_files[0]
-                filename, data = await file_table.pop(
+                _, data = await file_table.pop(
                     session, filename=ref.filename, url=ref.fetch_url
                 )
                 with zipfile.ZipFile(io.BytesIO(data)) as archive:
@@ -88,7 +89,7 @@ async def setup(settings: query.Setup):
                 network.setup(gbfs_files.stations.values())
             elif setting.type == "gtfs":
                 ref = setting.input_files[0]
-                filename, data = await file_table.pop(
+                _, data = await file_table.pop(
                     session, filename=ref.filename, url=ref.fetch_url
                 )
                 with zipfile.ZipFile(io.BytesIO(data)) as archive:
@@ -107,7 +108,7 @@ async def setup(settings: query.Setup):
                 network.setup(gtfs_files.trips.values())
             elif setting.type == "gtfs_flex":
                 ref = setting.input_files[0]
-                filename, data = await file_table.pop(
+                _, data = await file_table.pop(
                     session, filename=ref.filename, url=ref.fetch_url
                 )
                 with zipfile.ZipFile(io.BytesIO(data)) as archive:
@@ -150,7 +151,7 @@ async def plan(
     org: query.LocationSetting,
     dst: query.LocationSetting,
     dept: float,
-    arrv: typing.Optional[float] = None,
+    arrv: float | None = None,
 ):
     if arrv is not None:
         raise fastapi.HTTPException(

--- a/src/planner/simple/core.py
+++ b/src/planner/simple/core.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
-import typing
-from functools import cache
 
 from geopy.distance import great_circle
 
@@ -13,7 +11,6 @@ class Location:
     lat: float
     lng: float
 
-    @cache
     def distance(self, other: "Location"):
         # Remarks: self.distance(other) may not equal other.distance(self)
         return great_circle([self.lat, self.lng], [other.lat, other.lng]).meters
@@ -30,7 +27,7 @@ class Trip:
 
 @dataclasses.dataclass(frozen=True)
 class Path:
-    trips: typing.List[Trip]
+    trips: list[Trip]
     walking_time_minutes = 0.0
 
     @property

--- a/src/planner/simple/gbfs/network.py
+++ b/src/planner/simple/gbfs/network.py
@@ -1,13 +1,11 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import itertools
-import typing
 import logging
+import typing
 
 import networkx as nx
-
-from core import Location, Path, Trip, MobilityNetwork
-
+from core import Location, MobilityNetwork, Path, Trip
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +64,7 @@ class Network(MobilityNetwork):
             )
 
         # a list of nodes in the shortest path
-        nodes_on_path: typing.List[Node] = nx.shortest_path(
+        nodes_on_path: list[Node] = nx.shortest_path(
             self.graph, source=org, target=dst, weight="cost"
         )[1:-1]
 
@@ -89,7 +87,7 @@ class Network(MobilityNetwork):
             )
         ]
 
-        for a, b in zip(nodes_on_path, nodes_on_path[1:]):
+        for a, b in itertools.pairwise(nodes_on_path):
             dept = arrv
             arrv += a.location.distance(b.location) / self.mobility_velocity
             trips.append(

--- a/src/planner/simple/gbfs/reader.py
+++ b/src/planner/simple/gbfs/reader.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import io
-import zipfile
 import json
+import zipfile
 
 from core import Location
 

--- a/src/planner/simple/gtfs/network.py
+++ b/src/planner/simple/gtfs/network.py
@@ -1,14 +1,16 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-import typing
-import logging
 import datetime
+import itertools
+import logging
+import typing
 
 import networkx as nx
+from core import Location, MobilityNetwork, Path, Trip
 from networkx.exception import NetworkXNoPath
 
-from core import Location, Path, Trip, MobilityNetwork
-from gtfs.object import Trip as gtfs_Trip, StopTimeWithDatetime as StopTime
+from gtfs.object import StopTimeWithDatetime as StopTime
+from gtfs.object import Trip as gtfs_Trip
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +22,7 @@ class SchedulePoint(typing.NamedTuple):
 
 
 def add_nodes(graph: nx.DiGraph, stop_times: typing.Sequence[StopTime]):
-    for source, target in zip(stop_times, stop_times[1:]):
+    for source, target in itertools.pairwise(stop_times):
         # The "org" side is interested in departure times.
         graph.add_edge(
             u_of_edge=SchedulePoint(source.stop, source.departure, side="org"),
@@ -47,8 +49,8 @@ class Network(MobilityNetwork):
         self.start_time = start_time
         self.walking_velocity = walking_meters_per_minute
         self.max_waiting_bus_time = max_waiting_bus_time
-        self.graphs: typing.Dict[datetime.date, nx.DiGraph] = {}
-        self.trips: typing.List[gtfs_Trip] = []
+        self.graphs: dict[datetime.date, nx.DiGraph] = {}
+        self.trips: list[gtfs_Trip] = []
 
     def setup(self, trips: typing.Collection[gtfs_Trip]):
         self.trips = list(trips)
@@ -75,7 +77,7 @@ class Network(MobilityNetwork):
 
     def _nodes_on_shortest_path(
         self, graph: nx.DiGraph, org: Location, dst: Location, dept: datetime.datetime
-    ) -> typing.List[SchedulePoint]:
+    ) -> list[SchedulePoint]:
         # Add temporary nodes, indicating org/ dst location.
         # Nodes on the "org" side are only connected to org location.
         # Nodes on the "dst" side are only connected to dst location.
@@ -114,10 +116,10 @@ class Network(MobilityNetwork):
         # The station nearest to the source is preferentially selected.
         # Actually, a single list of nodes in the shortest path.
         try:
-            return sorted(
+            return min(
                 nx.all_shortest_paths(graph, source=org, target=dst, weight="weight"),
                 key=lambda path: path[1].stop.distance(org),
-            )[0][1:-1]
+            )[1:-1]
         except NetworkXNoPath:
             return []
         finally:
@@ -126,7 +128,7 @@ class Network(MobilityNetwork):
 
     def nodes_on_shortest_path(
         self, org: Location, dst: Location, dept: float
-    ) -> typing.List[SchedulePoint]:
+    ) -> list[SchedulePoint]:
         dept = self.datetime_from(dept)
         # graphs in the other day may contain more appropriate paths
         for graph in [

--- a/src/planner/simple/gtfs/object.py
+++ b/src/planner/simple/gtfs/object.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import typing
-from datetime import datetime, date, time, timedelta
+from datetime import date, datetime, time, timedelta
 
 from core import Location
 
@@ -35,8 +35,8 @@ class Service:
         self._start_day = start_date
         self._end_day = end_date
         self._weekday = [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
-        self._added_exceptions: typing.List[date] = []
-        self._removed_exceptions: typing.List[date] = []
+        self._added_exceptions: list[date] = []
+        self._removed_exceptions: list[date] = []
 
     def append_exception(self, exception_date: date, added=True):
         if added:
@@ -79,12 +79,12 @@ class StopTimeWithDatetime:
 class Trip:
     """Sequence of two or more stops that occur during a specific time period."""
 
-    def __init__(self, service: Service, stop_times: typing.List[StopTime]):
+    def __init__(self, service: Service, stop_times: list[StopTime]):
         assert len(stop_times) >= 2
         self.service = service
         self._stop_times = stop_times
 
-    def stop_times(self, at: date) -> typing.List[StopTimeWithDatetime]:
+    def stop_times(self, at: date) -> list[StopTimeWithDatetime]:
         return (
             [StopTimeWithDatetime(stop_time, at) for stop_time in self._stop_times]
             if self.service.is_operation(at)

--- a/src/planner/simple/gtfs/reader.py
+++ b/src/planner/simple/gtfs/reader.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 import collections
 import csv
-import typing
 import datetime
 import io
-import zipfile
 import re
+import typing
+import zipfile
 
 from core import Location
-from gtfs.object import StopTime, Service, Trip
 
+from gtfs.object import Service, StopTime, Trip
 
 p = re.compile(r"(\d\d?):(\d\d?):(\d\d?)")
 
@@ -25,13 +25,11 @@ def str_time(time: str):
 
 
 def str_date(time: str):
-    return datetime.datetime.strptime(time, "%Y%m%d").date()
+    return datetime.date.fromisoformat(f"{time[:4]}-{time[4:6]}-{time[6:8]}")
 
 
 class FileReader:
-    def __init__(
-        self, f, parse: typing.Callable[[typing.Dict[str, str]], typing.Tuple]
-    ):
+    def __init__(self, f, parse: typing.Callable[[dict[str, str]], tuple]):
         self.reader = csv.DictReader(io.TextIOWrapper(f, encoding="utf-8-sig"))
         self.parse = parse
 
@@ -42,13 +40,13 @@ class FileReader:
         return self.parse(next(self.reader))
 
 
-def parse_stop(row: typing.Dict[str, str]):
+def parse_stop(row: dict[str, str]):
     return row["stop_id"], Location(
         id_=row["stop_id"], lat=float(row["stop_lat"]), lng=float(row["stop_lon"])
     )
 
 
-def parse_calendar(row: typing.Dict[str, str]):
+def parse_calendar(row: dict[str, str]):
     return row["service_id"], Service(
         start_date=str_date(row["start_date"]),
         end_date=str_date(row["end_date"]),
@@ -62,18 +60,16 @@ def parse_calendar(row: typing.Dict[str, str]):
     )
 
 
-def parse_calendar_dates(row: typing.Dict[str, str]):
+def parse_calendar_dates(row: dict[str, str]):
     return row["service_id"], str_date(row["date"]), row["exception_type"] == "1"
 
 
 class FilesReader:
     def __init__(self, archive: zipfile.ZipFile):
-        self.stops: typing.Dict[str, Location] = {}
-        self._stop_times: typing.Dict[str, typing.List[StopTime]] = (
-            collections.defaultdict(list)
-        )
-        self._services: typing.Dict[str, Service] = {}
-        self.trips: typing.Dict[str, Trip] = {}
+        self.stops: dict[str, Location] = {}
+        self._stop_times: dict[str, list[StopTime]] = collections.defaultdict(list)
+        self._services: dict[str, Service] = {}
+        self.trips: dict[str, Trip] = {}
 
         with archive.open("stops.txt") as f:
             for k, v in FileReader(f, parse_stop):
@@ -97,14 +93,14 @@ class FilesReader:
             for k, v in FileReader(f, self.parse_trip):
                 self.trips.update({k: v})
 
-    def parse_stop_time(self, row: typing.Dict[str, str]):
+    def parse_stop_time(self, row: dict[str, str]):
         return row["trip_id"], StopTime(
             stop=self.stops[row["stop_id"]],
             arrival=str_time(row["arrival_time"]),
             departure=str_time(row["departure_time"]),
         )
 
-    def parse_trip(self, row: typing.Dict[str, str]):
+    def parse_trip(self, row: dict[str, str]):
         return row["trip_id"], Trip(
             service=self._services[row["service_id"]],
             stop_times=self._stop_times[row["trip_id"]],

--- a/src/planner/simple/gtfs_flex/network.py
+++ b/src/planner/simple/gtfs_flex/network.py
@@ -1,16 +1,16 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION
 # SPDX-License-Identifier: Apache-2.0
-import itertools
-import typing
-import logging
 import datetime
+import itertools
+import logging
+import typing
 
 import networkx as nx
+from core import Location, MobilityNetwork, Path, Trip
 from networkx.exception import NetworkXNoPath
 
-from core import Location, Path, Trip, MobilityNetwork
-from gtfs_flex.object import Trip as gtfs_Trip, Stop, StopTime
-
+from gtfs_flex.object import Stop, StopTime
+from gtfs_flex.object import Trip as gtfs_Trip
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +34,8 @@ class Network(MobilityNetwork):
         self.mobility_velocity = mobility_meters_per_minute
         self.walking_velocity = walking_meters_per_minute
         self.waiting_bus_time = expected_waiting_time
-        self.graphs: typing.Dict[datetime.date, nx.DiGraph] = {}
-        self.trips: typing.List[gtfs_Trip] = []
+        self.graphs: dict[datetime.date, nx.DiGraph] = {}
+        self.trips: list[gtfs_Trip] = []
 
     def setup(self, trips: typing.Collection[gtfs_Trip]):
         self.trips = trips
@@ -46,7 +46,7 @@ class Network(MobilityNetwork):
     def elapsed_until(self, date_time: datetime.datetime):
         return (date_time - self.start_time).total_seconds() / 60
 
-    def graph_from_stops(self, stops: typing.List[Stop]):
+    def graph_from_stops(self, stops: list[Stop]):
         graph = nx.DiGraph()
         for u, v in itertools.product(
             [Node(stop=stop, side="org") for stop in stops],
@@ -107,7 +107,7 @@ class Network(MobilityNetwork):
 
     def _nodes_on_shortest_path(
         self, graph: nx.DiGraph, org: Location, dst: Location
-    ) -> typing.Tuple[typing.List[Node], typing.List[float]]:
+    ) -> tuple[list[Node], list[float]]:
         # Add temporary nodes, indicating org/ dst location.
         for node in list(graph.nodes):
             node: Node
@@ -123,7 +123,7 @@ class Network(MobilityNetwork):
         # a list of nodes in the shortest path
         try:
             path = nx.shortest_path(graph, source=org, target=dst, weight="cost")
-            costs = [graph.edges[u, v]["cost"] for u, v in zip(path, path[1:])]
+            costs = [graph.edges[u, v]["cost"] for u, v in itertools.pairwise(path)]
             return path[1:-1], costs
         except NetworkXNoPath:
             return [], []
@@ -133,12 +133,12 @@ class Network(MobilityNetwork):
 
     def expected_arrival(
         self,
-        path: typing.List[Node],
-        costs: typing.List[float],
+        path: list[Node],
+        costs: list[float],
         dept: float,
         today: datetime.datetime,
         stop_time: StopTime,
-    ) -> typing.List[float]:
+    ) -> list[float]:
         assert len(path) == 2
         assert len(costs) == 3
         arrv0 = dept + costs[0]
@@ -166,7 +166,7 @@ class Network(MobilityNetwork):
 
     def nodes_on_shortest_path(
         self, org: Location, dst: Location, dept: float
-    ) -> typing.Tuple[typing.List[Node], typing.List[float]]:
+    ) -> tuple[list[Node], list[float]]:
         today = self.datetime_from(dept).replace(
             hour=0, minute=0, second=0, microsecond=0
         )

--- a/src/planner/simple/gtfs_flex/object.py
+++ b/src/planner/simple/gtfs_flex/object.py
@@ -17,7 +17,7 @@ class Stop(Location):
 class Group:
     """Group of stops"""
 
-    def __init__(self, group_id: str, name: str, locations: list[Stop] = None):
+    def __init__(self, group_id: str, name: str, locations: list[Stop] | None = None):
         self.group_id = group_id
         self.name = name
         self.locations: list[Stop] = locations if locations else []
@@ -44,8 +44,8 @@ class Service:
         self._start_day = start_date
         self._end_day = end_date
         self._weekday = [monday, tuesday, wednesday, thursday, friday, saturday, sunday]
-        self._added_exceptions: typing.List[date] = []
-        self._removed_exceptions: typing.List[date] = []
+        self._added_exceptions: list[date] = []
+        self._removed_exceptions: list[date] = []
 
     def append_exception(self, exception_date: date, added=True):
         if added:

--- a/src/planner/simple/gtfs_flex/reader.py
+++ b/src/planner/simple/gtfs_flex/reader.py
@@ -1,14 +1,13 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION
 # SPDX-License-Identifier: Apache-2.0
-import typing
-import datetime
 import csv
+import datetime
 import io
-import zipfile
 import re
+import typing
+import zipfile
 
-from gtfs_flex.object import Stop, Group, StopTime, Service, Trip
-
+from gtfs_flex.object import Group, Service, Stop, StopTime, Trip
 
 p = re.compile(r"(\d\d?):(\d\d?):(\d\d?)")
 
@@ -23,16 +22,16 @@ def str_time(time: str):
 
 
 def str_date(time: str):
-    return datetime.datetime.strptime(time, "%Y%m%d").date()
+    return datetime.date.fromisoformat(f"{time[:4]}-{time[4:6]}-{time[6:8]}")
 
 
 class FilesReader:
     def __init__(self, archive: zipfile.ZipFile):
-        self.stops: typing.Dict[str, Stop] = {}
-        self.location_groups: typing.Dict[str, Group] = {}
-        self._stop_times: typing.Dict[str, StopTime] = {}
-        self._services: typing.Dict[str, Service] = {}
-        self.trips: typing.Dict[str, Trip] = {}
+        self.stops: dict[str, Stop] = {}
+        self.location_groups: dict[str, Group] = {}
+        self._stop_times: dict[str, StopTime] = {}
+        self._services: dict[str, Service] = {}
+        self.trips: dict[str, Trip] = {}
         for filename, parse in {
             "stops.txt": self._parse_stop,
             "location_groups.txt": self._parse_location_groups,

--- a/src/planner/simple/jschema/query.py
+++ b/src/planner/simple/jschema/query.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
+import datetime
 import typing
 from enum import Enum
-import datetime
 
-from pydantic import BaseModel, AnyHttpUrl, model_validator, conlist, constr
+from pydantic import AnyHttpUrl, BaseModel, conlist, constr, model_validator
 
 
 class LocationSetting(BaseModel):
@@ -69,10 +69,8 @@ class Setup(BaseModel):
     reference_time: constr(min_length=8, max_length=8)
     networks: typing.Mapping[
         str,
-        typing.Union[
-            GtfsNetworkSetting,
-            GbfsNetworkSetting,
-            GtfsFlexNetworkSetting,
-            MaaSSimNetworkSetting,
-        ],
+        GtfsNetworkSetting
+        | GbfsNetworkSetting
+        | GtfsFlexNetworkSetting
+        | MaaSSimNetworkSetting,
     ]

--- a/src/planner/simple/route_planner.py
+++ b/src/planner/simple/route_planner.py
@@ -4,7 +4,7 @@ import logging
 import re
 import typing
 
-from core import Location, Path, Trip, MobilityNetwork
+from core import Location, MobilityNetwork, Path, Trip
 from jschema.response import DistanceMatrix
 
 logger = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ class Planner:
     ) -> DistanceMatrix:
         raise NotImplementedError()
 
-    def plan(self, org: Location, dst: Location, dept: float) -> typing.List[Path]:
+    def plan(self, org: Location, dst: Location, dept: float) -> list[Path]:
         raise NotImplementedError()
 
 

--- a/src/planner/simple/test_network.py
+++ b/src/planner/simple/test_network.py
@@ -1,21 +1,22 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION
 # SPDX-License-Identifier: Apache-2.0
 import datetime
-import typing
 import unittest
 
 from core import Location, Path, Trip, WalkingNetwork
-from gtfs.object import Trip as gtfs_Trip, StopTime, Service
-from gtfs.network import Network as GtfsNetwork
 from gbfs.network import Network as GbfsNetwork
-from gtfs_flex.object import (
-    Trip as flex_Trip,
-    Stop as flex_Stop,
-    StopTime as flex_StopTime,
-    Service as flex_Service,
-    Group as flex_Group,
-)
+from gtfs.network import Network as GtfsNetwork
+from gtfs.object import Service, StopTime
+from gtfs.object import Trip as gtfs_Trip
 from gtfs_flex.network import Network as GtfsFlexNetwork
+from gtfs_flex.object import Group as flex_Group
+from gtfs_flex.object import Service as flex_Service
+from gtfs_flex.object import Stop as flex_Stop
+from gtfs_flex.object import StopTime as flex_StopTime
+from gtfs_flex.object import Trip as flex_Trip
+
+BASE_DATE = datetime.date(2022, 1, 1)
+
 
 # 以下の地名、座標などは以下の著作物を改変して利用しています。
 # まいどはやバスGTFS-JP、富山市、クリエイティブ・コモンズ・ライセンス　表示4.0国際
@@ -172,12 +173,10 @@ class GtfsTestCase(unittest.TestCase):
         self.network = GtfsNetwork(
             service=self.service_name,
             walking_meters_per_minute=self.walking_velocity,
-            start_time=datetime.datetime.combine(
-                datetime.date.today(), datetime.time()
-            ),
+            start_time=datetime.datetime.combine(BASE_DATE, datetime.time()),
         )
         self.stations = gtfs_stations
-        schedule: typing.List[typing.Tuple[Location, float]] = [
+        schedule: list[tuple[Location, float]] = [
             (self.stations["3_1"], 543),
             (self.stations["7_1"], 548),
             (self.stations["11_1"], 558),
@@ -191,8 +190,8 @@ class GtfsTestCase(unittest.TestCase):
 
         trip = gtfs_Trip(
             service=Service(
-                start_date=datetime.date.today(),
-                end_date=datetime.date.today() + datetime.timedelta(days=1),
+                start_date=BASE_DATE,
+                end_date=BASE_DATE + datetime.timedelta(days=1),
                 monday=True,
                 tuesday=True,
                 wednesday=True,
@@ -261,17 +260,15 @@ class OndemandBusTestCase(unittest.TestCase):
             walking_meters_per_minute=self.walking_velocity,
             mobility_meters_per_minute=self.mobility_velocity,
             expected_waiting_time=self.expected_waiting_time,
-            start_time=datetime.datetime.combine(
-                datetime.date.today(), datetime.time()
-            ),
+            start_time=datetime.datetime.combine(BASE_DATE, datetime.time()),
         )
         self.stations = gtfs_flex_stations
         self.network.setup(
             [
                 flex_Trip(
                     service=flex_Service(
-                        start_date=datetime.date.today(),
-                        end_date=datetime.date.today() + datetime.timedelta(days=1),
+                        start_date=BASE_DATE,
+                        end_date=BASE_DATE + datetime.timedelta(days=1),
                         monday=True,
                         tuesday=True,
                         wednesday=True,

--- a/src/scenario/commuter/commuter.py
+++ b/src/scenario/commuter/commuter.py
@@ -5,7 +5,6 @@ import typing
 from dataclasses import dataclass
 
 import simpy
-
 from core import DemandEvent, DemandInfo, Location
 from jschema.query import CommuterSetting
 

--- a/src/scenario/commuter/controller.py
+++ b/src/scenario/commuter/controller.py
@@ -4,7 +4,6 @@ import logging
 import math
 
 import fastapi
-
 from commuter import CommuterScenario
 from jschema.query import Setup
 from jschema.response import Message, Peek, Step, StepEvent, User

--- a/src/scenario/commuter/jschema/response.py
+++ b/src/scenario/commuter/jschema/response.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
-from pydantic import BaseModel
 import typing
 
 from mblib.jschema import response
 from mblib.jschema.events import DemandEvent
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/scenario/generator/controller.py
+++ b/src/scenario/generator/controller.py
@@ -4,7 +4,6 @@ import logging
 import math
 
 import fastapi
-
 from generator import DemandGenerator
 from jschema import query, response
 from mblib.io.log import init_logger

--- a/src/scenario/generator/generator.py
+++ b/src/scenario/generator/generator.py
@@ -5,10 +5,9 @@ import logging
 import random
 import typing
 
-import simpy
-
 import jschema.query
-from core import Location, DemandEvent, DemandInfo
+import simpy
+from core import DemandEvent, DemandInfo, Location
 
 logger = logging.getLogger(__name__)
 

--- a/src/scenario/generator/jschema/response.py
+++ b/src/scenario/generator/jschema/response.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import typing
 
-from pydantic import BaseModel
-
 from mblib.jschema import response
 from mblib.jschema.events import DemandEvent
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/scenario/generator/test/test_scenario.py
+++ b/src/scenario/generator/test/test_scenario.py
@@ -3,7 +3,7 @@
 import unittest
 
 from generator import DemandGenerator
-from jschema.query import LocationSetting, Setup, SenDemandsSetting
+from jschema.query import LocationSetting, SenDemandsSetting, Setup
 from jschema.response import DemandEvent
 
 org1 = LocationSetting(locationId="Org", lat=154.1, lng=27.1)

--- a/src/scenario/generator/test/test_scenario_with_recv.py
+++ b/src/scenario/generator/test/test_scenario_with_recv.py
@@ -3,7 +3,7 @@
 import unittest
 
 from generator import DemandGenerator
-from jschema.query import LocationSetting, Setup, SenDemandsSetting
+from jschema.query import LocationSetting, SenDemandsSetting, Setup
 from jschema.response import DemandEvent
 
 org1 = LocationSetting(locationId="Org", lat=154.1, lng=27.1)

--- a/src/scenario/historical/controller.py
+++ b/src/scenario/historical/controller.py
@@ -4,7 +4,6 @@ import logging
 import math
 
 import fastapi
-
 from historical import HistoricalScenario
 from jschema import query, response
 from mblib.io.log import init_logger

--- a/src/scenario/historical/historical.py
+++ b/src/scenario/historical/historical.py
@@ -1,14 +1,12 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
+import itertools
 import logging
 import typing
-import itertools
-
 from dataclasses import dataclass
 
 import simpy
-
-from core import Location, DemandEvent, DemandInfo
+from core import DemandEvent, DemandInfo, Location
 from jschema.query import HistoricalDemandSetting
 
 logger = logging.getLogger(__name__)

--- a/src/scenario/historical/jschema/response.py
+++ b/src/scenario/historical/jschema/response.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import typing
 
-from pydantic import BaseModel
-
 from mblib.jschema import response
 from mblib.jschema.events import DemandEvent
+from pydantic import BaseModel
 
 Message = response.Message
 Peek = response.Peek

--- a/src/scenario/historical/test/test_scenario.py
+++ b/src/scenario/historical/test/test_scenario.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import unittest
 
+from historical import HistoricalScenario
 from jschema.query import HistoricalDemandSetting, LocationSetting
 from jschema.response import DemandEvent
-from historical import HistoricalScenario
 
 org = LocationSetting(locationId="Org", lat=154.1, lng=27.1)
 dst = LocationSetting(locationId="Dst", lat=154.2, lng=27.3)

--- a/src/simulation_broker/controller.py
+++ b/src/simulation_broker/controller.py
@@ -8,15 +8,12 @@ import pathlib
 import typing
 
 import fastapi
-
-
-from mblib.io.log import init_logger
-from mblib.io.result import FileResultWriter, HTTPResultWriter, ResultWriter
 from engine import RunnerEngine
 from jschema import query, response
-from runner import Runner
-from route_planner import Planner, Path
-from runner import HttpRunner
+from mblib.io.log import init_logger
+from mblib.io.result import FileResultWriter, HTTPResultWriter, ResultWriter
+from route_planner import Path, Planner
+from runner import HttpRunner, Runner
 from validation import EventValidator
 
 logger = logging.getLogger(__name__)
@@ -118,13 +115,13 @@ class Manager:
     def add_planner(self, name: str, planner: Planner):
         self.planners[name] = planner
 
-    def run(self, until: int | float | None, background_tasks: fastapi.BackgroundTasks):
+    def run(self, until: float | None, background_tasks: fastapi.BackgroundTasks):
         self.running = True
         background_tasks.add_task(self._run, until)
         # asyncio.create_task(_run(until))
         return {"message": "successfully run."}
 
-    async def _run(self, until: int | float):
+    async def _run(self, until: float):
         now = 0.0
         while now <= until and self.success:
             try:
@@ -134,7 +131,7 @@ class Manager:
                 logger.error("error on running: %s", repr(ex))
             except Exception as ex:
                 self.error = ex
-                logger.exception("error on running: %s", repr(ex))
+                logger.exception("error on running")
         self.running = False
 
     async def finish(self):
@@ -214,7 +211,7 @@ async def step():
 
 
 @app.post("/run", response_model=response.Message)
-def run(until: int | float | None, background_tasks: fastapi.BackgroundTasks):
+def run(until: float | None, background_tasks: fastapi.BackgroundTasks):
     manager.run(until, background_tasks)
     return {"message": "successfully run."}
 

--- a/src/simulation_broker/engine.py
+++ b/src/simulation_broker/engine.py
@@ -5,7 +5,6 @@ import logging
 import typing
 
 from jschema.event import Event
-
 from mblib.io.result import ResultWriter
 from mblib.jschema.spec import SpecificationResponse
 from validation import EventValidator
@@ -70,7 +69,7 @@ class RunnerEngine:
             await asyncio.gather(*[runner.peek() for runner in self._runners.values()])
         )
 
-    async def step(self, until: int | float = None) -> int | float:
+    async def step(self, until: float | None = None) -> int | float:
         peeks = await asyncio.gather(
             *[runner.peek() for runner in self._runners.values()]
         )

--- a/src/simulation_broker/jschema/query.py
+++ b/src/simulation_broker/jschema/query.py
@@ -3,7 +3,7 @@
 import typing
 from enum import Enum
 
-from pydantic import BaseModel, RootModel, AnyHttpUrl
+from pydantic import AnyHttpUrl, BaseModel, RootModel
 
 
 class LocationSetting(BaseModel):

--- a/src/simulation_broker/route_planner.py
+++ b/src/simulation_broker/route_planner.py
@@ -5,9 +5,8 @@ import logging
 import typing
 
 import aiohttp
-
-from mblib.io import httputil
 from jschema.query import LocationSetting
+from mblib.io import httputil
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +29,7 @@ class Trip:
 
 @dataclasses.dataclass(frozen=True)
 class Path:
-    trips: typing.List[Trip]
+    trips: list[Trip]
     # walking_time_minutes: float
 
 
@@ -42,7 +41,7 @@ class Planner:
     async def finish(self):
         await self._session.close()
 
-    async def _get(self, method: str, params: typing.Mapping = None):
+    async def _get(self, method: str, params: typing.Mapping | None = None):
         async with self._session.get(
             self._endpoint + method,
             params=params if params else {},
@@ -51,7 +50,10 @@ class Planner:
             return await response.json()
 
     async def _post(
-        self, method: str, data: typing.Mapping = None, params: typing.Mapping = None
+        self,
+        method: str,
+        data: typing.Mapping | None = None,
+        params: typing.Mapping | None = None,
     ):
         async with self._session.post(
             self._endpoint + method,

--- a/src/simulation_broker/runner.py
+++ b/src/simulation_broker/runner.py
@@ -4,8 +4,7 @@ import logging
 import typing
 
 import aiohttp
-
-from engine import Runner, Event
+from engine import Event, Runner
 from mblib.io import httputil
 from mblib.jschema.spec import SpecificationResponse
 
@@ -21,7 +20,7 @@ class HttpRunner(Runner):
     def __str__(self):
         return f"HttpRunner({self.name}, {self._endpoint})"
 
-    async def _get(self, method: str, params: typing.Mapping = None):
+    async def _get(self, method: str, params: typing.Mapping | None = None):
         async with self._session.get(
             self._endpoint + method,
             params=params if params else {},
@@ -33,7 +32,7 @@ class HttpRunner(Runner):
         self,
         method: str,
         data: typing.Any = None,
-        params: typing.Mapping = None,
+        params: typing.Mapping | None = None,
         timeout_seconds=300,
     ):
         async with self._session.post(

--- a/src/simulation_broker/test/test_controller.py
+++ b/src/simulation_broker/test/test_controller.py
@@ -3,7 +3,6 @@ import unittest
 
 import pydantic
 import yaml
-
 from controller import SetupParser
 from jschema import query
 

--- a/src/simulation_broker/test/test_validation.py
+++ b/src/simulation_broker/test/test_validation.py
@@ -4,19 +4,19 @@ import copy
 import json
 import re
 import unittest
+from typing import ClassVar
 
 import pydantic
-from jsonschema.exceptions import ValidationError
-
 from jschema.event import Event
+from jsonschema.exceptions import ValidationError
 from mblib.jschema import events, spec
 from validation import (
-    JsonSchema,
-    SchemaCompatibilityChecker,
     EventValidator,
+    JsonSchema,
     MismatchFutureError,
     MismatchSchemaError,
     MismatchVersionError,
+    SchemaCompatibilityChecker,
 )
 
 
@@ -151,7 +151,7 @@ class SchemaCompatibilityCheckerTestCase(unittest.TestCase):
 
 
 class EventValidatorTestCase(unittest.TestCase):
-    specs = {
+    specs: ClassVar[dict[str, spec.SpecificationResponse]] = {
         "broker": spec.SpecificationResponse.model_validate(
             {
                 "version": "https://tmc.co.jp/maas-blender/v1/base-schema.json",

--- a/src/simulation_broker/validation.py
+++ b/src/simulation_broker/validation.py
@@ -9,12 +9,10 @@ from functools import cached_property
 
 import jsonschema
 import yaml
+from jschema.event import Event
+from mblib.jschema.spec import FeatureDefinition, SpecificationResponse, TxRx
 from pydantic import AnyHttpUrl
 from pydantic.json_schema import JsonSchemaValue
-
-from jschema.event import Event
-
-from mblib.jschema.spec import SpecificationResponse, TxRx, FeatureDefinition
 
 logger = logging.getLogger(__name__)
 EventType = str

--- a/src/user_model/favorite/controller.py
+++ b/src/user_model/favorite/controller.py
@@ -4,13 +4,12 @@ import logging
 
 import aiohttp
 import fastapi
-
 from core import Location, Route, Trip
-from event import ReservedEvent, DepartedEvent, ArrivedEvent
+from event import ArrivedEvent, DepartedEvent, ReservedEvent
 from jschema import query, response
 from mblib.io import httputil
 from mblib.io.log import init_logger
-from mblib.jschema import spec, events
+from mblib.jschema import events, spec
 from user_manager import UserManager
 
 logger = logging.getLogger(__name__)
@@ -105,16 +104,12 @@ async def setup(settings: query.Setup):
 
 @app.post("/start", response_model=response.Message)
 def start():
-    global manager
-
     manager.start()
     return {"message": "successfully started."}
 
 
 @app.get("/peek", response_model=response.Peek)
 def peek():
-    global manager
-
     peek_time = manager.peek()
 
     return {"next": peek_time if peek_time < float("inf") else -1}

--- a/src/user_model/favorite/event.py
+++ b/src/user_model/favorite/event.py
@@ -4,7 +4,6 @@ import logging
 from enum import Enum
 
 import simpy
-
 from core import Location, Route
 
 logger = logging.getLogger(__name__)

--- a/src/user_model/favorite/jschema/query.py
+++ b/src/user_model/favorite/jschema/query.py
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import math
-
-from pydantic import BaseModel, AnyHttpUrl, model_validator
 from enum import Enum
-from mblib.jschema.events import DemandEvent, ReservedEvent, DepartedEvent, ArrivedEvent
+
+from mblib.jschema.events import ArrivedEvent, DemandEvent, DepartedEvent, ReservedEvent
+from pydantic import AnyHttpUrl, BaseModel, model_validator
 
 
 class PlannerSetting(BaseModel):

--- a/src/user_model/favorite/jschema/response.py
+++ b/src/user_model/favorite/jschema/response.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from mblib.jschema import response
-from mblib.jschema.events import ReserveEvent, DepartEvent
+from mblib.jschema.events import DepartEvent, ReserveEvent
 
 Message = response.Message
 Peek = response.Peek

--- a/src/user_model/favorite/planner.py
+++ b/src/user_model/favorite/planner.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2023 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import aiohttp
-from mblib.io import httputil
 from core import Location, Route, Trip
+from mblib.io import httputil
 
 
 class Planner:

--- a/src/user_model/favorite/test/test_user_process.py
+++ b/src/user_model/favorite/test/test_user_process.py
@@ -3,13 +3,14 @@
 import unittest
 
 import simpy
-
-import planner
 import user_manager
 from core import Location, User
-from event import Manager as EventManager, ReserveEvent, ReservedEvent, DepartEvent
-from planner import Route
+from event import DepartEvent, ReservedEvent, ReserveEvent
+from event import Manager as EventManager
 from user_manager import UserManager
+
+import planner
+from planner import Route
 
 # 以下の地名、座標などは以下の著作物を改変して利用しています。
 # まいどはやバスGTFS-JP、富山市、クリエイティブ・コモンズ・ライセンス　表示4.0国際

--- a/src/user_model/favorite/user_manager.py
+++ b/src/user_model/favorite/user_manager.py
@@ -6,17 +6,20 @@ import dataclasses
 import itertools
 import logging
 
-from core import Runner, User, Task, Location, Route
+from core import Location, Route, Runner, Task, User
+from event import (
+    ArrivedEvent,
+    DepartedEvent,
+    DepartEvent,
+    EventIdentifier,
+    ReservedEvent,
+    ReserveEvent,
+)
 from event import (
     Manager as EventManager,
-    EventIdentifier,
-    ReserveEvent,
-    ReservedEvent,
-    DepartEvent,
-    DepartedEvent,
-    ArrivedEvent,
 )
 from jschema.query import SortType, UserType
+
 from planner import Planner
 
 logger = logging.getLogger(__name__)
@@ -31,7 +34,7 @@ class Trip(Task):
         service: str,
         dept: float,
         arrv: float | None = None,
-        fail: list[Task] = None,
+        fail: list[Task] | None = None,
     ):
         self.event_manager = manager
         self.service = service
@@ -153,7 +156,7 @@ class FavoriteRouteFilter(RouteFilter):
             return True
         if self.favorite_service == {"walking"}:
             return False
-        services = set(t.service for t in plan.trips)
+        services = {t.service for t in plan.trips}
         return bool(self.favorite_service & services)
 
     def _check_walking_limit(self, plan: Route) -> bool:
@@ -190,7 +193,9 @@ class Reserve(Task):
     (pre)reserve mobility before trip
     """
 
-    def __init__(self, manager: EventManager, route: Route, fail: list[Task] = None):
+    def __init__(
+        self, manager: EventManager, route: Route, fail: list[Task] | None = None
+    ):
         assert len(route.trips) == 3
         self.event_manager = manager
         self.route = route
@@ -354,7 +359,7 @@ class UserManager(Runner):
     def __init__(
         self,
         user_params: dict[str, UserType | None],
-        confirmed_services: list[str] = None,
+        confirmed_services: list[str] | None = None,
     ):
         super().__init__()
         self._event_manager = EventManager(env=self.env)

--- a/src/user_model/simple/controller.py
+++ b/src/user_model/simple/controller.py
@@ -3,12 +3,11 @@
 import logging
 
 import fastapi
-
 from core import Location, Route, Trip
-from event import ReservedEvent, DepartedEvent, ArrivedEvent
+from event import ArrivedEvent, DepartedEvent, ReservedEvent
 from jschema import query, response
 from mblib.io.log import init_logger
-from mblib.jschema import spec, events
+from mblib.jschema import events, spec
 from user_manager import UserManager
 
 logger = logging.getLogger(__name__)
@@ -84,16 +83,12 @@ async def setup(settings: query.Setup):
 
 @app.post("/start", response_model=response.Message)
 def start():
-    global manager
-
     manager.start()
     return {"message": "successfully started."}
 
 
 @app.get("/peek", response_model=response.Peek)
 def peek():
-    global manager
-
     peek_time = manager.peek()
 
     return {"next": peek_time if peek_time < float("inf") else -1}

--- a/src/user_model/simple/event.py
+++ b/src/user_model/simple/event.py
@@ -4,7 +4,6 @@ import logging
 from enum import Enum
 
 import simpy
-
 from core import Location, Route
 
 logger = logging.getLogger(__name__)

--- a/src/user_model/simple/jschema/query.py
+++ b/src/user_model/simple/jschema/query.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 from enum import Enum
-from pydantic import BaseModel, AnyHttpUrl
 
-from mblib.jschema.events import DemandEvent, ReservedEvent, DepartedEvent, ArrivedEvent
+from mblib.jschema.events import ArrivedEvent, DemandEvent, DepartedEvent, ReservedEvent
+from pydantic import AnyHttpUrl, BaseModel
 
 
 class PlannerSetting(BaseModel):

--- a/src/user_model/simple/jschema/response.py
+++ b/src/user_model/simple/jschema/response.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from mblib.jschema import response
-from mblib.jschema.events import ReserveEvent, DepartEvent
+from mblib.jschema.events import DepartEvent, ReserveEvent
 
 Message = response.Message
 Peek = response.Peek

--- a/src/user_model/simple/planner.py
+++ b/src/user_model/simple/planner.py
@@ -1,9 +1,8 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import aiohttp
-
-from mblib.io import httputil
 from core import Location, Route, Trip
+from mblib.io import httputil
 
 
 class Planner:

--- a/src/user_model/simple/test/test_user_process.py
+++ b/src/user_model/simple/test/test_user_process.py
@@ -3,14 +3,15 @@
 import unittest
 
 import simpy
-
-import planner
 import user_manager
 from core import Location, User
-from event import Manager as EventManager, ReserveEvent, ReservedEvent, DepartEvent
+from event import DepartEvent, ReservedEvent, ReserveEvent
+from event import Manager as EventManager
 from jschema.query import PreferenceMode
-from planner import Route
 from user_manager import UserManager
+
+import planner
+from planner import Route
 
 # 以下の地名、座標などは以下の著作物を改変して利用しています。
 # まいどはやバスGTFS-JP、富山市、クリエイティブ・コモンズ・ライセンス　表示4.0国際

--- a/src/user_model/simple/user_manager.py
+++ b/src/user_model/simple/user_manager.py
@@ -5,17 +5,20 @@ from __future__ import annotations
 import itertools
 import logging
 
-from jschema.query import PreferenceMode
-from core import Runner, User, Task, Location, Route
+from core import Location, Route, Runner, Task, User
+from event import (
+    ArrivedEvent,
+    DepartedEvent,
+    DepartEvent,
+    EventIdentifier,
+    ReservedEvent,
+    ReserveEvent,
+)
 from event import (
     Manager as EventManager,
-    EventIdentifier,
-    ReserveEvent,
-    ReservedEvent,
-    DepartEvent,
-    DepartedEvent,
-    ArrivedEvent,
 )
+from jschema.query import PreferenceMode
+
 from planner import Planner
 
 logger = logging.getLogger(__name__)
@@ -30,7 +33,7 @@ class Trip(Task):
         service: str,
         dept: float,
         arrv: float | None = None,
-        fail: list[Task] = None,
+        fail: list[Task] | None = None,
     ):
         self.event_manager = manager
         self.service = service
@@ -125,7 +128,9 @@ class Reserve(Task):
     (pre)reserve mobility before trip
     """
 
-    def __init__(self, manager: EventManager, route: Route, fail: list[Task] = None):
+    def __init__(
+        self, manager: EventManager, route: Route, fail: list[Task] | None = None
+    ):
         assert len(route.trips) == 3
         self.event_manager = manager
         self.route = route
@@ -302,7 +307,9 @@ class UserManager(Runner):
     confirmed_services: list[str]
 
     def __init__(
-        self, preference_mode: PreferenceMode, confirmed_services: list[str] = None
+        self,
+        preference_mode: PreferenceMode,
+        confirmed_services: list[str] | None = None,
     ):
         super().__init__()
         self._event_manager = EventManager(env=self.env)


### PR DESCRIPTION
This PR fixes the repository so that `ruff check` passes across the entire codebase.

> [!NOTE]
> Ruff is now configured to ignore `DTZ007` globally:
> ```toml
> [lint]
> ignore = ["DTZ007"]
> ```

This keeps lint green without changing the runtime behavior of modules that still intentionally rely on naive datetimes.
