### PR TITLE
Fix `BlockTrip` boundary time handling across adjacent trips

### DIFF
--- a/src/base_simulators/scheduled/core.py
+++ b/src/base_simulators/scheduled/core.py
@@ -60,7 +60,7 @@ class StopTime:
         arrival: timedelta | None = None,
         departure: timedelta | None = None,
     ):
-        assert arrival or departure
+        assert arrival is not None or departure is not None
         self.stop = stop
         self.arrival = arrival if arrival else departure
         self.departure = departure if departure else arrival
@@ -177,10 +177,10 @@ class Trip:
     def stops(self) -> list[Stop]:
         raise NotImplementedError()
 
-    def is_operation(self, at_date: date) -> bool:
+    def is_operation(self, at: date) -> bool:
         raise NotImplementedError()
 
-    def stop_times_at(self, at_date: date) -> list[StopTimeWithDateTime]:
+    def stop_times_at(self, at: date) -> list[StopTimeWithDateTime]:
         raise NotImplementedError()
 
     def start_time(self, at: date) -> datetime:

--- a/src/base_simulators/scheduled/test/test_internal.py
+++ b/src/base_simulators/scheduled/test/test_internal.py
@@ -484,5 +484,144 @@ class BlockTripTestCase(unittest.TestCase):
         self.assertEqual(expected_events, triggered_events)
 
 
+class BlockTripBoundaryTimeTestCase(unittest.TestCase):
+    def test_when_boundary_stops_have_arrival_and_departure(self):
+        reference_date = date(year=2024, month=4, day=1)
+        service = Service(
+            start_date=reference_date,
+            end_date=reference_date,
+            monday=True,
+        )
+        simulation = Simulation(
+            start_time=datetime.combine(reference_date, time()),
+            capacity=20,
+            trips={
+                "mobility": BlockTrip(
+                    trips=[
+                        SingleTrip(
+                            route=...,
+                            service=service,
+                            stop_times=[
+                                StopTime(
+                                    stop=gtfs_stations["3_1"],
+                                    departure=timedelta(minutes=543),
+                                ),
+                                StopTime(
+                                    stop=gtfs_stations["7_1"],
+                                    arrival=timedelta(minutes=548),
+                                    departure=timedelta(minutes=560),
+                                ),
+                            ],
+                            block_id="a",
+                        ),
+                        SingleTrip(
+                            route=...,
+                            service=service,
+                            stop_times=[
+                                StopTime(
+                                    stop=gtfs_stations["7_1"],
+                                    arrival=timedelta(minutes=555),
+                                    departure=timedelta(minutes=566),
+                                ),
+                                StopTime(
+                                    stop=gtfs_stations["15_1"],
+                                    arrival=timedelta(minutes=574),
+                                    departure=timedelta(minutes=580),
+                                ),
+                            ],
+                            block_id="a",
+                        ),
+                    ]
+                )
+            },
+        )
+        simulation.start()
+
+        triggered_events = run(simulation, until=581)
+        operation_events = [
+            event
+            for event in triggered_events
+            if event["eventType"] in (EventType.ARRIVED, EventType.DEPARTED)
+        ]
+
+        self.assertEqual(6, len(operation_events))
+        self.assertEqual(574.0, operation_events[-2]["time"])
+        self.assertEqual(580.0, operation_events[-1]["time"])
+
+    def test_merge_boundaries_across_three_trips(self):
+        reference_date = date(year=2024, month=4, day=1)
+        service = Service(
+            start_date=reference_date,
+            end_date=reference_date,
+            monday=True,
+        )
+        block_trip = BlockTrip(
+            trips=[
+                SingleTrip(
+                    route=...,
+                    service=service,
+                    stop_times=[
+                        StopTime(
+                            stop=gtfs_stations["3_1"], departure=timedelta(minutes=543)
+                        ),
+                        StopTime(
+                            stop=gtfs_stations["7_1"],
+                            arrival=timedelta(minutes=548),
+                            departure=timedelta(minutes=560),
+                        ),
+                    ],
+                    block_id="a",
+                ),
+                SingleTrip(
+                    route=...,
+                    service=service,
+                    stop_times=[
+                        StopTime(
+                            stop=gtfs_stations["7_1"],
+                            arrival=timedelta(minutes=555),
+                            departure=timedelta(minutes=566),
+                        ),
+                        StopTime(
+                            stop=gtfs_stations["11_1"],
+                            arrival=timedelta(minutes=574),
+                            departure=timedelta(minutes=580),
+                        ),
+                    ],
+                    block_id="a",
+                ),
+                SingleTrip(
+                    route=...,
+                    service=service,
+                    stop_times=[
+                        StopTime(
+                            stop=gtfs_stations["11_1"],
+                            arrival=timedelta(minutes=578),
+                            departure=timedelta(minutes=585),
+                        ),
+                        StopTime(
+                            stop=gtfs_stations["15_1"],
+                            arrival=timedelta(minutes=590),
+                            departure=timedelta(minutes=595),
+                        ),
+                    ],
+                    block_id="a",
+                ),
+            ]
+        )
+
+        stop_times = [
+            each.stop_time for each in block_trip.stop_times_at(reference_date)
+        ]
+        self.assertEqual(4, len(stop_times))
+        self.assertEqual(timedelta(minutes=543), stop_times[0].arrival)
+        self.assertEqual(timedelta(minutes=543), stop_times[0].departure)
+        self.assertEqual(timedelta(minutes=548), stop_times[1].arrival)
+        self.assertEqual(timedelta(minutes=566), stop_times[1].departure)
+        self.assertEqual(timedelta(minutes=574), stop_times[2].arrival)
+        self.assertEqual(timedelta(minutes=585), stop_times[2].departure)
+        self.assertEqual(timedelta(minutes=590), stop_times[3].arrival)
+        self.assertEqual(timedelta(minutes=595), stop_times[3].departure)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/base_simulators/scheduled/trip.py
+++ b/src/base_simulators/scheduled/trip.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2022 TOYOTA MOTOR CORPORATION and MaaS Blender Contributors
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
+import itertools
 from datetime import date
 
 from core import Path, Route, Service, Stop, StopTime, StopTimeWithDateTime, Trip
@@ -25,9 +26,9 @@ class SingleTrip(Trip):
     def is_operation(self, at: date) -> bool:
         return self.service.is_operation(at)
 
-    def stop_times_at(self, at_date: date):
+    def stop_times_at(self, at: date):
         return [
-            StopTimeWithDateTime(stop_time=stop_time, reference_date=at_date)
+            StopTimeWithDateTime(stop_time=stop_time, reference_date=at)
             for stop_time in self.stop_times
         ]
 
@@ -60,10 +61,11 @@ class BlockTrip(Trip):
 
     def __post_init__(self):
         assert len(self.trips) >= 2
-        assert len({trip.block_id for trip in self.trips}) <= 1
+        assert len({trip.block_id for trip in self.trips}) == 1
         assert self.trips[0].block_id != ""
 
         # The following assertion is generally true for most cases,
+        # Trips in a block are expected to be ordered by first stop departure.
         assert (
             self.trips[0].stop_times[0].departure
             < self.trips[1].stop_times[0].departure
@@ -76,15 +78,67 @@ class BlockTrip(Trip):
     def is_operation(self, at: date) -> bool:
         return any(trip.service.is_operation(at) for trip in self.trips)
 
+    def _normalized_stop_times(self, at: date) -> list[StopTime]:
+        operating_trips = [trip for trip in self.trips if trip.service.is_operation(at)]
+        if not operating_trips:
+            return []
+
+        normalized: list[StopTime] = [
+            StopTime(
+                stop=stop_time.stop,
+                arrival=stop_time.arrival,
+                departure=stop_time.departure,
+            )
+            for stop_time in operating_trips[0].stop_times
+        ]
+
+        for previous_trip, current_trip in itertools.pairwise(operating_trips):
+            previous_last = normalized[-1]
+            current_first = current_trip.stop_times[0]
+            assert (
+                previous_trip.stop_times[0].departure
+                < current_trip.stop_times[0].departure
+            )
+            if previous_last.stop == current_first.stop:
+                normalized[-1] = StopTime(
+                    stop=previous_last.stop,
+                    arrival=previous_last.arrival,
+                    departure=current_first.departure,
+                )
+                next_trip_stop_times = current_trip.stop_times[1:]
+            else:
+                normalized[-1] = StopTime(
+                    stop=previous_last.stop,
+                    arrival=previous_last.arrival,
+                    departure=previous_last.arrival,
+                )
+                normalized.append(
+                    StopTime(
+                        stop=current_first.stop,
+                        arrival=current_first.departure,
+                        departure=current_first.departure,
+                    )
+                )
+                next_trip_stop_times = current_trip.stop_times[1:]
+
+            normalized.extend(
+                StopTime(
+                    stop=stop_time.stop,
+                    arrival=stop_time.arrival,
+                    departure=stop_time.departure,
+                )
+                for stop_time in next_trip_stop_times
+            )
+
+        return normalized
+
     def stop_times_at(self, at: date):
         # Depending on the service configuration, a block trip can be split into multiple trips
         # instead of being treated as a single block trip depending on the day of the week,
         # but this will not be considered for now.
         return [
             StopTimeWithDateTime(stop_time=stop_time, reference_date=at)
-            for trip in self.trips
-            if trip.service.is_operation(at)
-            for stop_time in trip.stop_times
+            for stop_time in self._normalized_stop_times(at)
         ]
 
     def start_time(self, at: date):


### PR DESCRIPTION
This PR fixes a bug in `BlockTrip` when adjacent SingleTrip segments share the same stop at the boundary.

Previously, the block schedule could duplicate boundary stops or produce incorrect arrival/departure timings, especially when a trip starts or ends at the same stop as the next trip.