### PR TITLE
Fix negative delays when overnight GTFS trips continue past midnight

### DIFF
--- a/src/base_simulators/scheduled/mobility.py
+++ b/src/base_simulators/scheduled/mobility.py
@@ -115,23 +115,28 @@ class Car(Mobility):
 
     def run(self):
         while True:
-            if trip := self.trip():
-                # 時刻表に従って順番に停車駅に移動する。
-                for plan in trip.stop_times_at(self.operation_date):
-                    yield self.env.timeout_until(plan.arrival)
-                    self._arrive(plan.stop)
-                    yield self.env.timeout_until(plan.departure)
-                    self._departure()
+            trip = self.trip()
 
-                assert not self.passengers, f"remain users on end: {self}"
-
-            else:
-                # If there is no operation for the day, wait until the next day.
+            # If there is no operation for the day, wait until the next day.
+            if trip is None:
                 yield self.env.timeout_until(
                     datetime.combine(
                         self.current_datetime.date() + timedelta(days=1), time()
                     )
                 )
+                continue
+
+            # Move to the next stop in order according to the gtfs timetable,
+            for plan in trip.stop_times_at(self.operation_date):
+                # Ignore already-completed stops and only advance to future service points.
+                if plan.arrival < self.current_datetime:
+                    continue
+                yield self.env.timeout_until(plan.arrival)
+                self._arrive(plan.stop)
+                yield self.env.timeout_until(plan.departure)
+                self._departure()
+
+            assert not self.passengers, f"remain users on end: {self}"
 
     def __str__(self):
         data = {

--- a/src/base_simulators/scheduled/test/test_internal.py
+++ b/src/base_simulators/scheduled/test/test_internal.py
@@ -83,6 +83,80 @@ class SingleTripTestCase(unittest.TestCase):
         )
         self.simulation.start()
 
+    def test_overnight_trip_should_skip_past_stops_when_simulation_starts_after_midnight(
+        self,
+    ):
+        start_date = date(year=2024, month=4, day=1)
+        sim = Simulation(
+            start_time=datetime.combine(start_date, time()),
+            capacity=20,
+            trips={
+                "mobility": SingleTrip(
+                    route=...,
+                    service=Service(
+                        start_date=start_date - timedelta(days=1),
+                        end_date=start_date + timedelta(days=2),
+                        monday=True,
+                        tuesday=True,
+                        wednesday=True,
+                        thursday=True,
+                        friday=True,
+                        saturday=True,
+                        sunday=True,
+                    ),
+                    stop_times=[
+                        StopTime(
+                            stop=gtfs_stations["3_1"],
+                            departure=timedelta(hours=23, minutes=55),
+                        ),
+                        StopTime(
+                            stop=gtfs_stations["7_1"],
+                            arrival=timedelta(hours=23, minutes=59),
+                            departure=timedelta(days=1, hours=0, minutes=5),
+                        ),
+                        StopTime(
+                            stop=gtfs_stations["11_1"],
+                            arrival=timedelta(days=1, hours=0, minutes=15),
+                            departure=timedelta(days=1, hours=0, minutes=15),
+                        ),
+                        StopTime(
+                            stop=gtfs_stations["15_1"],
+                            arrival=timedelta(days=1, hours=0, minutes=25),
+                            departure=timedelta(days=1, hours=0, minutes=25),
+                        ),
+                    ],
+                )
+            },
+        )
+        sim.start()
+
+        triggered_events = run(sim, until=1480)
+
+        expected_operation_events = [
+            (EventType.ARRIVED, 15.0, "11_1"),
+            (EventType.DEPARTED, 15.0, "11_1"),
+            (EventType.ARRIVED, 25.0, "15_1"),
+            (EventType.DEPARTED, 25.0, "15_1"),
+            (EventType.ARRIVED, 1435.0, "3_1"),
+            (EventType.DEPARTED, 1435.0, "3_1"),
+            (EventType.ARRIVED, 1439.0, "7_1"),
+            (EventType.DEPARTED, 1445.0, "7_1"),
+            (EventType.ARRIVED, 1455.0, "11_1"),
+            (EventType.DEPARTED, 1455.0, "11_1"),
+            (EventType.ARRIVED, 1465.0, "15_1"),
+            (EventType.DEPARTED, 1465.0, "15_1"),
+        ]
+        actual_operation_events = [
+            (
+                event["eventType"],
+                event["time"],
+                event["details"]["location"]["locationId"],
+            )
+            for event in triggered_events
+            if event["eventType"] in (EventType.ARRIVED, EventType.DEPARTED)
+        ]
+        self.assertEqual(expected_operation_events, actual_operation_events)
+
     def test_operation(self):
         triggered_events = run(self.simulation, until=549)
         expected_events = [


### PR DESCRIPTION
This PR addresses a scheduling issue in the `scheduled` simulator when GTFS trips continue past midnight and the simulation starts at midnight.

The bug occurred because overnight trip progression could be evaluated against the previous day’s reference date. As a result, the simulator could iterate from earlier stop times in the trip, including arrivals that had already passed, which led to negative delays.

The fix ensures that, before scheduling the next event, stop times whose arrival is already in the past are skipped. This guarantees that delay calculations are performed only for future times.