### PR TITLE
Bump OpenTripPlanner from 2.6.0 to 2.9.0

### DIFF
--- a/src/planner/opentripplanner/Dockerfile
+++ b/src/planner/opentripplanner/Dockerfile
@@ -1,20 +1,26 @@
 FROM python:3.11-slim
 
-ARG jdk_version=21
-ARG otp_version=2.6.0
+ARG jdk_version=25
+ARG otp_version=2.9.0
 ARG jdk_url=https://download.oracle.com/java/${jdk_version}/latest/jdk-${jdk_version}_linux-x64_bin.deb
-ARG otp_url=https://repo1.maven.org/maven2/org/opentripplanner/otp/${otp_version}/otp-${otp_version}-shaded.jar
 
-RUN apt-get update && apt-get install -y \
-    wget \
-    git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update  \
+  && apt-get install -y wget git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN wget ${jdk_url} \
  && dpkg -i jdk-*_linux-x64_bin.deb \
- && mkdir /var/otp \
- && wget ${otp_url} -O /var/otp/otp-shaded.jar
+ && rm jdk-*_linux-x64_bin.deb
+
+# OTPバージョンに応じてURLを振り分け
+RUN if [ $(echo "${otp_version}" | cut -d. -f1-2 | tr -d '.') -lt 27 ]; then \
+    OTP_URL="https://repo1.maven.org/maven2/org/opentripplanner/otp/${otp_version}/otp-${otp_version}-shaded.jar"; \
+  else \
+    OTP_URL="https://repo1.maven.org/maven2/org/opentripplanner/otp-shaded/${otp_version}/otp-shaded-${otp_version}.jar"; \
+  fi && \
+  mkdir /var/otp && \
+  wget ${OTP_URL} -O /var/otp/otp-shaded.jar
 
 COPY requirements.txt ./
 ENV PIP_ROOT_USER_ACTION=ignore


### PR DESCRIPTION
This PR updates the OpenTripPlanner integration to match the 2.9.0 release.

### Changes
- Bump OpenTripPlanner from 2.6.0 to 2.9.0
- Upgrade the JDK from 21 to 25
- Switch the OTP download source
  - from: `org/opentripplanner/otp/.../otp-${version}-shaded.jar`
  - to: `org/opentripplanner/otp-shaded/.../otp-shaded-${version}.jar`
